### PR TITLE
Aides include national dex Pokemon in count

### DIFF
--- a/data/maps/Route10_PokemonCenter_1F/scripts.inc
+++ b/data/maps/Route10_PokemonCenter_1F/scripts.inc
@@ -37,7 +37,7 @@ Route10_PokemonCenter_1F_EventScript_Aide:: @ 816FC65
 	msgbox Route10_PokemonCenter_1F_Text_GiveEverstoneIfCaught20Mons, MSGBOX_YESNO
 	compare VAR_RESULT, NO
 	goto_if_eq Aide_EventScript_DeclineCheckMons
-	setvar VAR_0x8004, 0
+	setvar VAR_0x8004, 1
 	specialvar VAR_RESULT, GetPokedexCount
 	getnumberstring 2, VAR_0x8006
 	call Route10_PokemonCenter_1F_EventScript_GetAideRequestInfo

--- a/data/maps/Route11_EastEntrance_2F/scripts.inc
+++ b/data/maps/Route11_EastEntrance_2F/scripts.inc
@@ -64,7 +64,7 @@ Route11_EastEntrance_2F_EventScript_Aide:: @ 816FDD8
 	msgbox Route11_EastEntrance_2F_Text_GiveItemfinderIfCaught30, MSGBOX_YESNO
 	compare VAR_RESULT, NO
 	goto_if_eq Aide_EventScript_DeclineCheckMons
-	setvar VAR_0x8004, 0
+	setvar VAR_0x8004, 1
 	specialvar VAR_RESULT, GetPokedexCount
 	getnumberstring 2, VAR_0x8006
 	call Route11_EastEntrance_2F_EventScript_GetAideRequestInfo

--- a/data/maps/Route15_WestEntrance_2F/scripts.inc
+++ b/data/maps/Route15_WestEntrance_2F/scripts.inc
@@ -27,7 +27,7 @@ Route15_WestEntrance_2F_EventScript_Aide:: @ 81700B9
 	msgbox Route15_WestEntrance_2F_Text_GiveItemIfCaughtEnough, MSGBOX_YESNO
 	compare VAR_RESULT, NO
 	goto_if_eq Aide_EventScript_DeclineCheckMons
-	setvar VAR_0x8004, 0
+	setvar VAR_0x8004, 1
 	specialvar VAR_RESULT, GetPokedexCount
 	getnumberstring 2, VAR_0x8006
 	call Route15_WestEntrance_2F_EventScript_GetAideRequestInfo

--- a/data/maps/Route16_NorthEntrance_2F/scripts.inc
+++ b/data/maps/Route16_NorthEntrance_2F/scripts.inc
@@ -27,7 +27,7 @@ Route16_NorthEntrance_2F_EventScript_Aide:: @ 81702E3
 	msgbox Route16_NorthEntrance_2F_Text_GiveAmuletCoinIfCaught40, MSGBOX_YESNO
 	compare VAR_RESULT, NO
 	goto_if_eq Aide_EventScript_DeclineCheckMons
-	setvar VAR_0x8004, 0
+	setvar VAR_0x8004, 1
 	specialvar VAR_RESULT, GetPokedexCount
 	getnumberstring 2, VAR_0x8006
 	call Route16_NorthEntrance_2F_EventScript_GetAideRequestInfo

--- a/data/maps/Route2_EastBuilding/scripts.inc
+++ b/data/maps/Route2_EastBuilding/scripts.inc
@@ -11,7 +11,7 @@ Route2_EastBuilding_EventScript_Aide:: @ 816F67F
 	msgbox Route2_EastBuilding_Text_GiveHM05IfSeen10Mons, MSGBOX_YESNO
 	compare VAR_RESULT, NO
 	goto_if_eq Aide_EventScript_DeclineCheckMons
-	setvar VAR_0x8004, 0
+	setvar VAR_0x8004, 1
 	specialvar VAR_RESULT, GetPokedexCount
 	getnumberstring 2, VAR_0x8006
 	call Route2_EastBuilding_EventScript_GetAideRequestInfo


### PR DESCRIPTION
Whenever `getPokedexCount` is called, it checks a variable to see whether it should count natdex Pokemon or not. Normally, all the aides call the function with that variable set to 0 (so just look at Kanto dex). It's now set to 1 before calling it in the scripts the aides use, which tells the function to include Pokemon from outside Kanto. 