### PR TITLE
Add constant MOVE_COUNT to GetBoxMonData

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -3195,7 +3195,7 @@ u32 GetBoxMonData(struct BoxPokemon *boxMon, s32 field, u8 *data)
             u16 *moves = (u16 *)data;
             s32 i = 0;
 
-            while (moves[i] != 355)
+            while (moves[i] != MOVES_COUNT)
             {
                 u16 move = moves[i];
                 if (substruct1->moves[0] == move


### PR DESCRIPTION
Fixes bug where the game would hang when a Pokemon was released for ~2 minutes.