### PR TITLE
Wild Dusclops max level 93 -> 39

### DIFF
--- a/src/data/wild_encounters.json
+++ b/src/data/wild_encounters.json
@@ -2427,7 +2427,7 @@
               },
               {
                 "min_level": 38,
-                "max_level": 93,
+                "max_level": 39,
                 "species": "SPECIES_DUSCLOPS"
               },
               {
@@ -10228,7 +10228,7 @@
             ]
           }
         }
-	]
+      ]
     }
   ]
 }


### PR DESCRIPTION
Quick fix for a typo