### PR TITLE
Silph Co 1F One Way Warp Warning

### DIFF
--- a/data/maps/BirthIsland_Exterior/map.json
+++ b/data/maps/BirthIsland_Exterior/map.json
@@ -13,10 +13,11 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
+  "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_METEORITE",
+      "in_connection": false,
       "x": 15,
       "y": 12,
       "elevation": 3,
@@ -30,6 +31,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_VAR_0",
+      "in_connection": false,
       "x": 15,
       "y": 3,
       "elevation": 3,
@@ -51,6 +53,10 @@
       "dest_warp_id": 0
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/CeruleanCave_1F/map.json
+++ b/data/maps/CeruleanCave_1F/map.json
@@ -13,10 +13,11 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
+  "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 7,
       "y": 3,
       "elevation": 3,
@@ -30,6 +31,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 11,
       "y": 16,
       "elevation": 3,
@@ -43,6 +45,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 25,
       "y": 5,
       "elevation": 4,
@@ -56,6 +59,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 7,
       "y": 21,
       "elevation": 3,
@@ -69,6 +73,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 13,
       "y": 21,
       "elevation": 3,
@@ -82,6 +87,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 5,
       "y": 20,
       "elevation": 3,
@@ -95,6 +101,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 14,
       "y": 20,
       "elevation": 3,
@@ -108,6 +115,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 11,
       "y": 21,
       "elevation": 3,
@@ -121,6 +129,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 9,
       "y": 18,
       "elevation": 3,
@@ -191,7 +200,9 @@
       "dest_warp_id": 5
     }
   ],
-  "coord_events": [],
+  "coord_events": [
+
+  ],
   "bg_events": [
     {
       "type": "hidden_item",

--- a/data/maps/CeruleanCave_2F/map.json
+++ b/data/maps/CeruleanCave_2F/map.json
@@ -13,10 +13,11 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
+  "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 9,
       "y": 18,
       "elevation": 3,
@@ -30,6 +31,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 29,
       "y": 16,
       "elevation": 3,
@@ -43,6 +45,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 33,
       "y": 12,
       "elevation": 3,
@@ -56,6 +59,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 33,
       "y": 10,
       "elevation": 3,
@@ -69,6 +73,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 33,
       "y": 9,
       "elevation": 3,
@@ -82,6 +87,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 25,
       "y": 11,
       "elevation": 3,
@@ -95,6 +101,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 28,
       "y": 20,
       "elevation": 3,
@@ -108,6 +115,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 30,
       "y": 20,
       "elevation": 3,
@@ -121,6 +129,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 9,
       "y": 13,
       "elevation": 3,
@@ -134,6 +143,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 23,
       "y": 16,
       "elevation": 3,
@@ -147,6 +157,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 13,
       "y": 6,
       "elevation": 3,
@@ -160,6 +171,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 4,
       "y": 12,
       "elevation": 3,
@@ -173,6 +185,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 10,
       "y": 20,
       "elevation": 3,
@@ -229,6 +242,10 @@
       "dest_warp_id": 7
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/CeruleanCave_B1F/map.json
+++ b/data/maps/CeruleanCave_B1F/map.json
@@ -13,10 +13,11 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
+  "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 31,
       "y": 9,
       "elevation": 4,
@@ -29,20 +30,8 @@
       "flag": "FLAG_HIDE_CERULEAN_CAVE_B1F_ULTRA_BALL"
     },
     {
-      "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "x": 32,
-      "y": 2,
-      "elevation": 3,
-      "movement_type": "MOVEMENT_TYPE_FACE_DOWN",
-      "movement_range_x": 1,
-      "movement_range_y": 1,
-      "trainer_type": "TRAINER_TYPE_NONE",
-      "trainer_sight_or_berry_tree_id": "0",
-      "script": "CeruleanCave_B1F_EventScript_ItemMaxRevive",
-      "flag": "FLAG_HIDE_CERULEAN_CAVE_B1F_MAX_REVIVE"
-    },
-    {
       "graphics_id": "OBJ_EVENT_GFX_MEWTWO",
+      "in_connection": false,
       "x": 7,
       "y": 12,
       "elevation": 3,
@@ -56,6 +45,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 37,
       "y": 1,
       "elevation": 3,
@@ -69,6 +59,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 38,
       "y": 2,
       "elevation": 3,
@@ -82,6 +73,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 35,
       "y": 1,
       "elevation": 3,
@@ -95,6 +87,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 37,
       "y": 4,
       "elevation": 3,
@@ -108,6 +101,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 35,
       "y": 5,
       "elevation": 3,
@@ -121,6 +115,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 2,
       "y": 2,
       "elevation": 3,
@@ -134,6 +129,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 4,
       "y": 1,
       "elevation": 3,
@@ -147,6 +143,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 6,
       "y": 1,
       "elevation": 3,
@@ -160,6 +157,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 3,
       "y": 4,
       "elevation": 3,
@@ -181,6 +179,10 @@
       "dest_warp_id": 2
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/CeruleanCave_B1F/scripts.inc
+++ b/data/maps/CeruleanCave_B1F/scripts.inc
@@ -28,14 +28,14 @@ CeruleanCave_B1F_EventScript_Mewtwo:: @ 81624F5
 	lock
 	faceplayer
 	waitse
-	playmoncry SPECIES_MEWTWO, 2
+	playmoncry SPECIES_Ditto, 2
 	message CeruleanCave_B1F_Text_Mew
 	waitmessage
 	waitmoncry
 	delay 20
 	playbgm MUS_EXEYE, 0
 	waitbuttonpress
-	setwildbattle SPECIES_MEWTWO, 70, ITEM_NONE
+	setwildbattle SPECIES_DITTO, 70, ITEM_NONE
 	setflag FLAG_SYS_SPECIAL_WILD_BATTLE
 	special StartLegendaryBattle
 	waitstate
@@ -57,6 +57,6 @@ CeruleanCave_B1F_EventScript_DefeatedMewtwo:: @ 8162558
 	end
 
 CeruleanCave_B1F_EventScript_RanFromMewtwo:: @ 8162561
-	setvar VAR_0x8004, SPECIES_MEWTWO
+	setvar VAR_0x8004, SPECIES_DITTO
 	goto EventScript_MonFlewAway
 	end

--- a/data/maps/CeruleanCave_B1F/scripts.inc
+++ b/data/maps/CeruleanCave_B1F/scripts.inc
@@ -28,7 +28,7 @@ CeruleanCave_B1F_EventScript_Mewtwo:: @ 81624F5
 	lock
 	faceplayer
 	waitse
-	playmoncry SPECIES_Ditto, 2
+	playmoncry SPECIES_DITTO, 2
 	message CeruleanCave_B1F_Text_Mew
 	waitmessage
 	waitmoncry

--- a/data/maps/FiveIsland_LostCave_Entrance/map.json
+++ b/data/maps/FiveIsland_LostCave_Entrance/map.json
@@ -13,8 +13,10 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
-  "object_events": [],
+  "connections": 0,
+  "object_events": [
+
+  ],
   "warp_events": [
     {
       "x": 5,
@@ -31,6 +33,10 @@
       "dest_warp_id": 0
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/FiveIsland_LostCave_Room1/map.json
+++ b/data/maps/FiveIsland_LostCave_Room1/map.json
@@ -13,10 +13,11 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
+  "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_HIKER",
+      "in_connection": false,
       "x": 5,
       "y": 4,
       "elevation": 3,
@@ -66,6 +67,10 @@
       "dest_warp_id": 2
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/FiveIsland_LostCave_Room10/map.json
+++ b/data/maps/FiveIsland_LostCave_Room10/map.json
@@ -13,10 +13,11 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
+  "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_WOMAN_2",
+      "in_connection": false,
       "x": 5,
       "y": 5,
       "elevation": 3,
@@ -30,6 +31,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 5,
       "y": 2,
       "elevation": 3,
@@ -51,6 +53,10 @@
       "dest_warp_id": 1
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/FiveIsland_LostCave_Room11/map.json
+++ b/data/maps/FiveIsland_LostCave_Room11/map.json
@@ -13,10 +13,11 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
+  "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 5,
       "y": 5,
       "elevation": 3,
@@ -38,6 +39,10 @@
       "dest_warp_id": 3
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/FiveIsland_LostCave_Room12/map.json
+++ b/data/maps/FiveIsland_LostCave_Room12/map.json
@@ -13,10 +13,11 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
+  "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 5,
       "y": 5,
       "elevation": 3,
@@ -38,6 +39,10 @@
       "dest_warp_id": 1
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/FiveIsland_LostCave_Room13/map.json
+++ b/data/maps/FiveIsland_LostCave_Room13/map.json
@@ -13,21 +13,9 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
+  "connections": 0,
   "object_events": [
-    {
-      "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "x": 5,
-      "y": 5,
-      "elevation": 3,
-      "movement_type": "MOVEMENT_TYPE_FACE_DOWN",
-      "movement_range_x": 1,
-      "movement_range_y": 1,
-      "trainer_type": "TRAINER_TYPE_NONE",
-      "trainer_sight_or_berry_tree_id": "0",
-      "script": "FiveIsland_LostCave_Room13_EventScript_ItemMaxRevive",
-      "flag": "FLAG_HIDE_FIVE_ISLAND_LOST_CAVE_ROOM13_MAX_REVIVE"
-    }
+
   ],
   "warp_events": [
     {
@@ -38,6 +26,10 @@
       "dest_warp_id": 2
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/FiveIsland_LostCave_Room14/map.json
+++ b/data/maps/FiveIsland_LostCave_Room14/map.json
@@ -13,10 +13,11 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
+  "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 5,
       "y": 5,
       "elevation": 3,
@@ -38,6 +39,10 @@
       "dest_warp_id": 4
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/FiveIsland_LostCave_Room2/map.json
+++ b/data/maps/FiveIsland_LostCave_Room2/map.json
@@ -13,8 +13,10 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
-  "object_events": [],
+  "connections": 0,
+  "object_events": [
+
+  ],
   "warp_events": [
     {
       "x": 5,
@@ -45,6 +47,10 @@
       "dest_warp_id": 2
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/FiveIsland_LostCave_Room3/map.json
+++ b/data/maps/FiveIsland_LostCave_Room3/map.json
@@ -13,8 +13,10 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
-  "object_events": [],
+  "connections": 0,
+  "object_events": [
+
+  ],
   "warp_events": [
     {
       "x": 5,
@@ -45,6 +47,10 @@
       "dest_warp_id": 2
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/FiveIsland_LostCave_Room4/map.json
+++ b/data/maps/FiveIsland_LostCave_Room4/map.json
@@ -13,10 +13,11 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
+  "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_WOMAN_1",
+      "in_connection": false,
       "x": 6,
       "y": 4,
       "elevation": 3,
@@ -59,6 +60,10 @@
       "dest_warp_id": 2
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/FiveIsland_LostCave_Room5/map.json
+++ b/data/maps/FiveIsland_LostCave_Room5/map.json
@@ -13,8 +13,10 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
-  "object_events": [],
+  "connections": 0,
+  "object_events": [
+
+  ],
   "warp_events": [
     {
       "x": 5,
@@ -45,6 +47,10 @@
       "dest_warp_id": 2
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/FiveIsland_LostCave_Room6/map.json
+++ b/data/maps/FiveIsland_LostCave_Room6/map.json
@@ -13,8 +13,10 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
-  "object_events": [],
+  "connections": 0,
+  "object_events": [
+
+  ],
   "warp_events": [
     {
       "x": 5,
@@ -45,6 +47,10 @@
       "dest_warp_id": 1
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/FiveIsland_LostCave_Room7/map.json
+++ b/data/maps/FiveIsland_LostCave_Room7/map.json
@@ -13,8 +13,10 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
-  "object_events": [],
+  "connections": 0,
+  "object_events": [
+
+  ],
   "warp_events": [
     {
       "x": 5,
@@ -45,6 +47,10 @@
       "dest_warp_id": 2
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/FiveIsland_LostCave_Room8/map.json
+++ b/data/maps/FiveIsland_LostCave_Room8/map.json
@@ -13,8 +13,10 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
-  "object_events": [],
+  "connections": 0,
+  "object_events": [
+
+  ],
   "warp_events": [
     {
       "x": 5,
@@ -45,6 +47,10 @@
       "dest_warp_id": 0
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/FiveIsland_LostCave_Room9/map.json
+++ b/data/maps/FiveIsland_LostCave_Room9/map.json
@@ -13,8 +13,10 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
-  "object_events": [],
+  "connections": 0,
+  "object_events": [
+
+  ],
   "warp_events": [
     {
       "x": 5,
@@ -45,6 +47,10 @@
       "dest_warp_id": 2
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/FiveIsland_Meadow/map.json
+++ b/data/maps/FiveIsland_Meadow/map.json
@@ -99,20 +99,6 @@
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
       "in_connection": false,
-      "x": 12,
-      "y": 11,
-      "elevation": 3,
-      "movement_type": "MOVEMENT_TYPE_FACE_DOWN",
-      "movement_range_x": 1,
-      "movement_range_y": 1,
-      "trainer_type": "TRAINER_TYPE_NONE",
-      "trainer_sight_or_berry_tree_id": "0",
-      "script": "FiveIsland_Meadow_EventScript_ItemMaxPotion",
-      "flag": "FLAG_HIDE_FIVE_ISLAND_MEADOW_MAX_POTION"
-    },
-    {
-      "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "in_connection": false,
       "x": 3,
       "y": 22,
       "elevation": 3,

--- a/data/maps/FiveIsland_MemorialPillar/map.json
+++ b/data/maps/FiveIsland_MemorialPillar/map.json
@@ -15,14 +15,15 @@
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
   "connections": [
     {
-      "map": "MAP_FIVE_ISLAND_MEADOW",
+      "direction": "left",
       "offset": -20,
-      "direction": "left"
+      "map": "MAP_FIVE_ISLAND_MEADOW"
     }
   ],
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_MAN",
+      "in_connection": false,
       "x": 8,
       "y": 44,
       "elevation": 4,
@@ -36,6 +37,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKER",
+      "in_connection": false,
       "x": 12,
       "y": 6,
       "elevation": 3,
@@ -49,6 +51,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKER",
+      "in_connection": false,
       "x": 14,
       "y": 17,
       "elevation": 3,
@@ -62,6 +65,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKER",
+      "in_connection": false,
       "x": 17,
       "y": 31,
       "elevation": 3,
@@ -75,6 +79,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 4,
       "y": 47,
       "elevation": 3,
@@ -87,8 +92,12 @@
       "flag": "FLAG_HIDE_FIVE_ISLAND_MEMORIAL_PILLAR_METAL_COAT"
     }
   ],
-  "warp_events": [],
-  "coord_events": [],
+  "warp_events": [
+
+  ],
+  "coord_events": [
+
+  ],
   "bg_events": [
     {
       "type": "sign",
@@ -110,16 +119,6 @@
     },
     {
       "type": "hidden_item",
-      "x": 15,
-      "y": 7,
-      "elevation": 3,
-      "item": "ITEM_RAZZ_BERRY",
-      "flag": "HIDDEN_ITEM_FIVE_ISLAND_MEMORIAL_PILLAR_RAZZ_BERRY",
-      "quantity": 1,
-      "underfoot": false
-    },
-    {
-      "type": "hidden_item",
       "x": 17,
       "y": 22,
       "elevation": 3,
@@ -135,6 +134,16 @@
       "elevation": 3,
       "item": "ITEM_BLUK_BERRY",
       "flag": "HIDDEN_ITEM_FIVE_ISLAND_MEMORIAL_PILLAR_BLUK_BERRY",
+      "quantity": 1,
+      "underfoot": false
+    },
+    {
+      "type": "hidden_item",
+      "x": 15,
+      "y": 7,
+      "elevation": 3,
+      "item": "ITEM_RAZZ_BERRY",
+      "flag": "HIDDEN_ITEM_FIVE_ISLAND_MEMORIAL_PILLAR_RAZZ_BERRY",
       "quantity": 1,
       "underfoot": false
     }

--- a/data/maps/FiveIsland_ResortGorgeous/map.json
+++ b/data/maps/FiveIsland_ResortGorgeous/map.json
@@ -15,14 +15,15 @@
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
   "connections": [
     {
-      "map": "MAP_FIVE_ISLAND_WATER_LABYRINTH",
+      "direction": "down",
       "offset": -48,
-      "direction": "down"
+      "map": "MAP_FIVE_ISLAND_WATER_LABYRINTH"
     }
   ],
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_LASS",
+      "in_connection": false,
       "x": 44,
       "y": 10,
       "elevation": 3,
@@ -36,6 +37,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_LASS",
+      "in_connection": false,
       "x": 33,
       "y": 12,
       "elevation": 3,
@@ -49,6 +51,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_LASS",
+      "in_connection": false,
       "x": 12,
       "y": 10,
       "elevation": 3,
@@ -62,6 +65,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_WOMAN_2",
+      "in_connection": false,
       "x": 23,
       "y": 9,
       "elevation": 3,
@@ -75,6 +79,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_WOMAN_2",
+      "in_connection": false,
       "x": 33,
       "y": 8,
       "elevation": 3,
@@ -88,6 +93,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_YOUNGSTER",
+      "in_connection": false,
       "x": 33,
       "y": 3,
       "elevation": 3,
@@ -101,6 +107,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_SWIMMER_M_WATER",
+      "in_connection": false,
       "x": 56,
       "y": 7,
       "elevation": 1,
@@ -114,6 +121,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_WOMAN_2",
+      "in_connection": false,
       "x": 39,
       "y": 9,
       "elevation": 3,
@@ -142,7 +150,9 @@
       "dest_warp_id": 0
     }
   ],
-  "coord_events": [],
+  "coord_events": [
+
+  ],
   "bg_events": [
     {
       "type": "hidden_item",

--- a/data/maps/FiveIsland_RocketWarehouse/map.json
+++ b/data/maps/FiveIsland_RocketWarehouse/map.json
@@ -13,10 +13,11 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_INDOOR_2",
-  "connections": null,
+  "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_M",
+      "in_connection": false,
       "x": 15,
       "y": 11,
       "elevation": 3,
@@ -30,6 +31,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_M",
+      "in_connection": false,
       "x": 17,
       "y": 15,
       "elevation": 3,
@@ -43,6 +45,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_F",
+      "in_connection": false,
       "x": 27,
       "y": 16,
       "elevation": 3,
@@ -56,6 +59,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_M",
+      "in_connection": false,
       "x": 25,
       "y": 11,
       "elevation": 3,
@@ -69,6 +73,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_F",
+      "in_connection": false,
       "x": 6,
       "y": 6,
       "elevation": 3,
@@ -82,6 +87,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_SCIENTIST",
+      "in_connection": false,
       "x": 27,
       "y": 4,
       "elevation": 3,
@@ -95,6 +101,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 8,
       "y": 25,
       "elevation": 3,
@@ -108,6 +115,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 17,
       "y": 3,
       "elevation": 0,
@@ -121,6 +129,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 1,
       "y": 16,
       "elevation": 3,
@@ -134,6 +143,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 4,
       "y": 5,
       "elevation": 3,

--- a/data/maps/FourIsland/map.json
+++ b/data/maps/FourIsland/map.json
@@ -13,10 +13,11 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
+  "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_OLD_MAN_1",
+      "in_connection": false,
       "x": 16,
       "y": 13,
       "elevation": 3,
@@ -30,6 +31,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_DODUO",
+      "in_connection": false,
       "x": 12,
       "y": 9,
       "elevation": 3,
@@ -43,6 +45,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_NIDORAN_F",
+      "in_connection": false,
       "x": 13,
       "y": 7,
       "elevation": 3,
@@ -56,6 +59,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_NIDORAN_M",
+      "in_connection": false,
       "x": 14,
       "y": 7,
       "elevation": 3,
@@ -69,6 +73,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PSYDUCK",
+      "in_connection": false,
       "x": 17,
       "y": 9,
       "elevation": 3,
@@ -82,6 +87,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_OLD_WOMAN",
+      "in_connection": false,
       "x": 26,
       "y": 19,
       "elevation": 3,
@@ -95,6 +101,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 5,
       "y": 11,
       "elevation": 3,
@@ -108,6 +115,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 5,
       "y": 6,
       "elevation": 3,
@@ -121,6 +129,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 32,
       "y": 19,
       "elevation": 3,
@@ -134,6 +143,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BLUE",
+      "in_connection": false,
       "x": 8,
       "y": 25,
       "elevation": 3,
@@ -147,6 +157,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_FAT_MAN",
+      "in_connection": false,
       "x": 36,
       "y": 13,
       "elevation": 3,
@@ -160,6 +171,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_LITTLE_GIRL",
+      "in_connection": false,
       "x": 31,
       "y": 21,
       "elevation": 3,
@@ -230,7 +242,9 @@
       "dest_warp_id": 0
     }
   ],
-  "coord_events": [],
+  "coord_events": [
+
+  ],
   "bg_events": [
     {
       "type": "sign",

--- a/data/maps/FourIsland_IcefallCave_1F/map.json
+++ b/data/maps/FourIsland_IcefallCave_1F/map.json
@@ -13,10 +13,11 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
+  "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 11,
       "y": 7,
       "elevation": 3,
@@ -30,6 +31,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 12,
       "y": 16,
       "elevation": 3,
@@ -86,6 +88,10 @@
       "dest_warp_id": 0
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/FourIsland_IcefallCave_B1F/map.json
+++ b/data/maps/FourIsland_IcefallCave_B1F/map.json
@@ -13,10 +13,11 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
+  "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 10,
       "y": 14,
       "elevation": 3,
@@ -30,6 +31,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 21,
       "y": 7,
       "elevation": 3,
@@ -65,6 +67,10 @@
       "dest_warp_id": 4
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/FourIsland_IcefallCave_Back/map.json
+++ b/data/maps/FourIsland_IcefallCave_Back/map.json
@@ -13,10 +13,11 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
+  "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_M",
+      "in_connection": false,
       "x": 11,
       "y": 14,
       "elevation": 3,
@@ -30,6 +31,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_M",
+      "in_connection": false,
       "x": 13,
       "y": 14,
       "elevation": 3,
@@ -43,6 +45,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_LORELEI",
+      "in_connection": false,
       "x": 12,
       "y": 16,
       "elevation": 3,
@@ -56,6 +59,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_M",
+      "in_connection": false,
       "x": 10,
       "y": 15,
       "elevation": 3,
@@ -106,5 +110,7 @@
       "script": "FourIsland_IcefallCave_Back_EventScript_LoreleiRocketsScene"
     }
   ],
-  "bg_events": []
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/NavelRock_1F/map.json
+++ b/data/maps/NavelRock_1F/map.json
@@ -13,8 +13,10 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
-  "object_events": [],
+  "connections": 0,
+  "object_events": [
+
+  ],
   "warp_events": [
     {
       "x": 8,
@@ -31,6 +33,10 @@
       "dest_warp_id": 0
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/NavelRock_Exterior/map.json
+++ b/data/maps/NavelRock_Exterior/map.json
@@ -13,8 +13,10 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
-  "object_events": [],
+  "connections": 0,
+  "object_events": [
+
+  ],
   "warp_events": [
     {
       "x": 9,
@@ -31,6 +33,10 @@
       "dest_warp_id": 0
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/OneIsland_KindleRoad_EmberSpa/map.json
+++ b/data/maps/OneIsland_KindleRoad_EmberSpa/map.json
@@ -13,10 +13,11 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
+  "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_OLD_MAN_1",
+      "in_connection": false,
       "x": 11,
       "y": 13,
       "elevation": 3,
@@ -30,6 +31,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BALDING_MAN",
+      "in_connection": false,
       "x": 15,
       "y": 11,
       "elevation": 3,
@@ -43,6 +45,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BLACKBELT",
+      "in_connection": false,
       "x": 6,
       "y": 8,
       "elevation": 3,
@@ -56,6 +59,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_OLD_WOMAN",
+      "in_connection": false,
       "x": 20,
       "y": 7,
       "elevation": 3,
@@ -69,6 +73,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_OLD_MAN_1",
+      "in_connection": false,
       "x": 10,
       "y": 5,
       "elevation": 3,
@@ -82,6 +87,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BALDING_MAN",
+      "in_connection": false,
       "x": 11,
       "y": 20,
       "elevation": 3,
@@ -114,5 +120,7 @@
       "script": "OneIsland_KindleRoad_EmberSpa_EventScript_SpaHeal"
     }
   ],
-  "bg_events": []
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/Prototype_SeviiIsle_6/map.json
+++ b/data/maps/Prototype_SeviiIsle_6/map.json
@@ -15,13 +15,21 @@
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
   "connections": [
     {
-      "map": "MAP_THREE_ISLAND",
+      "direction": "up",
       "offset": 0,
-      "direction": "up"
+      "map": "MAP_THREE_ISLAND"
     }
   ],
-  "object_events": [],
-  "warp_events": [],
-  "coord_events": [],
-  "bg_events": []
+  "object_events": [
+
+  ],
+  "warp_events": [
+
+  ],
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/Prototype_SeviiIsle_7/map.json
+++ b/data/maps/Prototype_SeviiIsle_7/map.json
@@ -15,13 +15,21 @@
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
   "connections": [
     {
-      "map": "MAP_THREE_ISLAND",
+      "direction": "up",
       "offset": 0,
-      "direction": "up"
+      "map": "MAP_THREE_ISLAND"
     }
   ],
-  "object_events": [],
-  "warp_events": [],
-  "coord_events": [],
-  "bg_events": []
+  "object_events": [
+
+  ],
+  "warp_events": [
+
+  ],
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/SevenIsland/map.json
+++ b/data/maps/SevenIsland/map.json
@@ -15,19 +15,20 @@
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
   "connections": [
     {
-      "map": "MAP_SEVEN_ISLAND_TRAINER_TOWER",
+      "direction": "up",
       "offset": -48,
-      "direction": "up"
+      "map": "MAP_SEVEN_ISLAND_TRAINER_TOWER"
     },
     {
-      "map": "MAP_SEVEN_ISLAND_SEVAULT_CANYON_ENTRANCE",
+      "direction": "down",
       "offset": 0,
-      "direction": "down"
+      "map": "MAP_SEVEN_ISLAND_SEVAULT_CANYON_ENTRANCE"
     }
   ],
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_COOLTRAINER_M",
+      "in_connection": false,
       "x": 7,
       "y": 18,
       "elevation": 3,
@@ -41,6 +42,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_OLD_WOMAN",
+      "in_connection": false,
       "x": 9,
       "y": 7,
       "elevation": 3,
@@ -54,6 +56,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_SCIENTIST",
+      "in_connection": false,
       "x": 15,
       "y": 5,
       "elevation": 3,
@@ -96,7 +99,9 @@
       "dest_warp_id": 0
     }
   ],
-  "coord_events": [],
+  "coord_events": [
+
+  ],
   "bg_events": [
     {
       "type": "sign",

--- a/data/maps/SevenIsland_SevaultCanyon/map.json
+++ b/data/maps/SevenIsland_SevaultCanyon/map.json
@@ -15,19 +15,20 @@
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
   "connections": [
     {
-      "map": "MAP_SEVEN_ISLAND_TANOBY_RUINS",
+      "direction": "down",
       "offset": -48,
-      "direction": "down"
+      "map": "MAP_SEVEN_ISLAND_TANOBY_RUINS"
     },
     {
-      "map": "MAP_SEVEN_ISLAND_SEVAULT_CANYON_ENTRANCE",
+      "direction": "left",
       "offset": -20,
-      "direction": "left"
+      "map": "MAP_SEVEN_ISLAND_SEVAULT_CANYON_ENTRANCE"
     }
   ],
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_BATTLE_GIRL",
+      "in_connection": false,
       "x": 13,
       "y": 43,
       "elevation": 3,
@@ -41,6 +42,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_MAN",
+      "in_connection": false,
       "x": 13,
       "y": 36,
       "elevation": 3,
@@ -54,6 +56,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_CAMPER",
+      "in_connection": false,
       "x": 3,
       "y": 35,
       "elevation": 3,
@@ -67,6 +70,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PICNICKER",
+      "in_connection": false,
       "x": 3,
       "y": 36,
       "elevation": 3,
@@ -80,6 +84,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_COOLTRAINER_M",
+      "in_connection": false,
       "x": 7,
       "y": 56,
       "elevation": 3,
@@ -93,6 +98,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_COOLTRAINER_F",
+      "in_connection": false,
       "x": 11,
       "y": 63,
       "elevation": 3,
@@ -106,6 +112,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_COOLTRAINER_M",
+      "in_connection": false,
       "x": 14,
       "y": 13,
       "elevation": 3,
@@ -119,6 +126,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_COOLTRAINER_F",
+      "in_connection": false,
       "x": 14,
       "y": 14,
       "elevation": 3,
@@ -132,6 +140,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 3,
       "y": 41,
       "elevation": 3,
@@ -145,6 +154,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
+      "in_connection": false,
       "x": 13,
       "y": 47,
       "elevation": 3,
@@ -158,6 +168,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 7,
       "y": 44,
       "elevation": 3,
@@ -171,6 +182,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 12,
       "y": 47,
       "elevation": 3,
@@ -184,6 +196,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 15,
       "y": 46,
       "elevation": 3,
@@ -197,6 +210,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 16,
       "y": 47,
       "elevation": 3,
@@ -210,6 +224,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
+      "in_connection": false,
       "x": 17,
       "y": 47,
       "elevation": 3,
@@ -223,6 +238,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCK_SMASH_ROCK",
+      "in_connection": false,
       "x": 11,
       "y": 31,
       "elevation": 3,
@@ -236,6 +252,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 18,
       "y": 45,
       "elevation": 3,
@@ -249,6 +266,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 7,
       "y": 38,
       "elevation": 3,
@@ -262,6 +280,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 17,
       "y": 23,
       "elevation": 3,
@@ -275,6 +294,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BLACKBELT",
+      "in_connection": false,
       "x": 8,
       "y": 26,
       "elevation": 3,
@@ -303,7 +323,9 @@
       "dest_warp_id": 0
     }
   ],
-  "coord_events": [],
+  "coord_events": [
+
+  ],
   "bg_events": [
     {
       "type": "hidden_item",

--- a/data/maps/SevenIsland_SevaultCanyon_Entrance/map.json
+++ b/data/maps/SevenIsland_SevaultCanyon_Entrance/map.json
@@ -15,19 +15,20 @@
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
   "connections": [
     {
-      "map": "MAP_SEVEN_ISLAND",
+      "direction": "up",
       "offset": 0,
-      "direction": "up"
+      "map": "MAP_SEVEN_ISLAND"
     },
     {
-      "map": "MAP_SEVEN_ISLAND_SEVAULT_CANYON",
+      "direction": "right",
       "offset": 20,
-      "direction": "right"
+      "map": "MAP_SEVEN_ISLAND_SEVAULT_CANYON"
     }
   ],
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_WOMAN_2",
+      "in_connection": false,
       "x": 12,
       "y": 6,
       "elevation": 3,
@@ -41,6 +42,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BEAUTY",
+      "in_connection": false,
       "x": 3,
       "y": 34,
       "elevation": 3,
@@ -54,6 +56,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_MAN",
+      "in_connection": false,
       "x": 4,
       "y": 34,
       "elevation": 3,
@@ -67,6 +70,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_CAMPER",
+      "in_connection": false,
       "x": 11,
       "y": 26,
       "elevation": 3,
@@ -80,6 +84,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PICNICKER",
+      "in_connection": false,
       "x": 10,
       "y": 26,
       "elevation": 3,
@@ -93,6 +98,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKER",
+      "in_connection": false,
       "x": 11,
       "y": 17,
       "elevation": 5,
@@ -119,8 +125,12 @@
       "flag": "0"
     }
   ],
-  "warp_events": [],
-  "coord_events": [],
+  "warp_events": [
+
+  ],
+  "coord_events": [
+
+  ],
   "bg_events": [
     {
       "type": "hidden_item",

--- a/data/maps/SevenIsland_SevaultCanyon_TanobyKey/map.json
+++ b/data/maps/SevenIsland_SevaultCanyon_TanobyKey/map.json
@@ -13,10 +13,11 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_INDOOR_1",
-  "connections": null,
+  "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
+      "in_connection": false,
       "x": 7,
       "y": 6,
       "elevation": 3,
@@ -30,6 +31,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
+      "in_connection": false,
       "x": 8,
       "y": 6,
       "elevation": 3,
@@ -43,6 +45,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
+      "in_connection": false,
       "x": 8,
       "y": 9,
       "elevation": 3,
@@ -56,6 +59,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
+      "in_connection": false,
       "x": 6,
       "y": 10,
       "elevation": 3,
@@ -69,6 +73,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
+      "in_connection": false,
       "x": 8,
       "y": 10,
       "elevation": 3,
@@ -82,6 +87,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
+      "in_connection": false,
       "x": 6,
       "y": 9,
       "elevation": 3,
@@ -95,6 +101,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
+      "in_connection": false,
       "x": 6,
       "y": 6,
       "elevation": 3,
@@ -181,5 +188,7 @@
       "script": "SevenIsland_SevaultCanyon_TanobyKey_EventScript_Switch2"
     }
   ],
-  "bg_events": []
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/SevenIsland_TanobyRuins/map.json
+++ b/data/maps/SevenIsland_TanobyRuins/map.json
@@ -15,14 +15,15 @@
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
   "connections": [
     {
-      "map": "MAP_SEVEN_ISLAND_SEVAULT_CANYON",
+      "direction": "up",
       "offset": 48,
-      "direction": "up"
+      "map": "MAP_SEVEN_ISLAND_SEVAULT_CANYON"
     }
   ],
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_HIKER",
+      "in_connection": false,
       "x": 35,
       "y": 7,
       "elevation": 3,
@@ -36,6 +37,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_HIKER",
+      "in_connection": false,
       "x": 121,
       "y": 11,
       "elevation": 3,
@@ -49,6 +51,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_LASS",
+      "in_connection": false,
       "x": 85,
       "y": 8,
       "elevation": 3,
@@ -62,6 +65,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_GENTLEMAN",
+      "in_connection": false,
       "x": 85,
       "y": 5,
       "elevation": 3,
@@ -125,7 +129,9 @@
       "dest_warp_id": 0
     }
   ],
-  "coord_events": [],
+  "coord_events": [
+
+  ],
   "bg_events": [
     {
       "type": "hidden_item",

--- a/data/maps/SevenIsland_TanobyRuins_DilfordChamber/map.json
+++ b/data/maps/SevenIsland_TanobyRuins_DilfordChamber/map.json
@@ -13,8 +13,10 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_INDOOR_1",
-  "connections": null,
-  "object_events": [],
+  "connections": 0,
+  "object_events": [
+
+  ],
   "warp_events": [
     {
       "x": 11,
@@ -24,6 +26,10 @@
       "dest_warp_id": 3
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/SevenIsland_TanobyRuins_LiptooChamber/map.json
+++ b/data/maps/SevenIsland_TanobyRuins_LiptooChamber/map.json
@@ -13,8 +13,10 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_INDOOR_1",
-  "connections": null,
-  "object_events": [],
+  "connections": 0,
+  "object_events": [
+
+  ],
   "warp_events": [
     {
       "x": 11,
@@ -24,6 +26,10 @@
       "dest_warp_id": 1
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/SevenIsland_TanobyRuins_MoneanChamber/map.json
+++ b/data/maps/SevenIsland_TanobyRuins_MoneanChamber/map.json
@@ -13,8 +13,10 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_INDOOR_1",
-  "connections": null,
-  "object_events": [],
+  "connections": 0,
+  "object_events": [
+
+  ],
   "warp_events": [
     {
       "x": 11,
@@ -24,6 +26,10 @@
       "dest_warp_id": 0
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/SevenIsland_TanobyRuins_RixyChamber/map.json
+++ b/data/maps/SevenIsland_TanobyRuins_RixyChamber/map.json
@@ -13,8 +13,10 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_INDOOR_1",
-  "connections": null,
-  "object_events": [],
+  "connections": 0,
+  "object_events": [
+
+  ],
   "warp_events": [
     {
       "x": 11,
@@ -24,6 +26,10 @@
       "dest_warp_id": 5
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/SevenIsland_TanobyRuins_ScufibChamber/map.json
+++ b/data/maps/SevenIsland_TanobyRuins_ScufibChamber/map.json
@@ -13,8 +13,10 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_INDOOR_1",
-  "connections": null,
-  "object_events": [],
+  "connections": 0,
+  "object_events": [
+
+  ],
   "warp_events": [
     {
       "x": 11,
@@ -24,6 +26,10 @@
       "dest_warp_id": 4
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/SevenIsland_TanobyRuins_ViapoisChamber/map.json
+++ b/data/maps/SevenIsland_TanobyRuins_ViapoisChamber/map.json
@@ -13,8 +13,10 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_INDOOR_1",
-  "connections": null,
-  "object_events": [],
+  "connections": 0,
+  "object_events": [
+
+  ],
   "warp_events": [
     {
       "x": 11,
@@ -24,6 +26,10 @@
       "dest_warp_id": 6
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/SevenIsland_TanobyRuins_WeepthChamber/map.json
+++ b/data/maps/SevenIsland_TanobyRuins_WeepthChamber/map.json
@@ -13,8 +13,10 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_INDOOR_1",
-  "connections": null,
-  "object_events": [],
+  "connections": 0,
+  "object_events": [
+
+  ],
   "warp_events": [
     {
       "x": 11,
@@ -24,6 +26,10 @@
       "dest_warp_id": 2
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/SevenIsland_TrainerTower/map.json
+++ b/data/maps/SevenIsland_TrainerTower/map.json
@@ -15,14 +15,15 @@
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
   "connections": [
     {
-      "map": "MAP_SEVEN_ISLAND",
+      "direction": "down",
       "offset": 48,
-      "direction": "down"
+      "map": "MAP_SEVEN_ISLAND"
     }
   ],
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_BOY",
+      "in_connection": false,
       "x": 56,
       "y": 26,
       "elevation": 3,
@@ -36,6 +37,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_WOMAN_1",
+      "in_connection": false,
       "x": 56,
       "y": 29,
       "elevation": 3,
@@ -57,7 +59,9 @@
       "dest_warp_id": 1
     }
   ],
-  "coord_events": [],
+  "coord_events": [
+
+  ],
   "bg_events": [
     {
       "type": "hidden_item",

--- a/data/maps/SilphCo_1F/map.json
+++ b/data/maps/SilphCo_1F/map.json
@@ -35,12 +35,12 @@
       "x": 34,
       "y": 4,
       "elevation": 3,
-      "movement_type": "MOVEMENT_TYPE_NONE",
+      "movement_type": "MOVEMENT_TYPE_FACE_DOWN",
       "movement_range_x": 0,
       "movement_range_y": 0,
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "2",
-      "script": "NULL",
+      "script": "SilphCo_1F_EventScript_Scientist",
       "flag": "0"
     }
   ],
@@ -87,18 +87,18 @@
       "x": 34,
       "y": 5,
       "elevation": 0,
-      "var": "VAR_0x3F20",
+      "var": "VAR_TEMP_1",
       "var_value": "0",
-      "script": "NULL"
+      "script": "SilphCo_1F_EventScript_LockYouInTriggerTop"
     },
     {
       "type": "trigger",
       "x": 34,
       "y": 6,
       "elevation": 0,
-      "var": "VAR_0x3F20",
+      "var": "VAR_TEMP_1",
       "var_value": "0",
-      "script": "NULL"
+      "script": "SilphCo_1F_EventScript_LockYouInTriggerBottom"
     }
   ],
   "bg_events": [

--- a/data/maps/SilphCo_1F/scripts.inc
+++ b/data/maps/SilphCo_1F/scripts.inc
@@ -4,6 +4,7 @@ SilphCo_1F_MapScripts:: @ 8161625
 
 SilphCo_1F_OnTransition:: @ 816162B
 	setworldmapflag FLAG_WORLD_MAP_SILPH_CO_1F
+	call_if_set FLAG_HIDE_SILPH_ROCKETS, SilphCo_1F_EventScript_DisableLockYouInTrigger
 	end
 
 SilphCo_1F_EventScript_Receptionist:: @ 816162F
@@ -13,3 +14,52 @@ SilphCo_1F_EventScript_Receptionist:: @ 816162F
 SilphCo_1F_EventScript_FloorSign:: @ 8161638
 	msgbox SilphCo_1F_Text_FloorSign, MSGBOX_SIGN
 	end
+
+SilphCo_1F_EventScript_DisableLockYouInTrigger::
+	setvar VAR_TEMP_1, 1
+	return
+
+SilphCo_1F_EventScript_LockYouInTriggerTop::
+	lockall
+	setvar VAR_0x8008, 0
+	goto SilphCo_1F_EventScript_LockYouInTrigger
+	end
+
+SilphCo_1F_EventScript_LockYouInTriggerBottom::
+	lockall
+	setvar VAR_0x8008, 1
+	goto SilphCo_1F_EventScript_LockYouInTrigger
+	end
+
+SilphCo_1F_EventScript_LockYouInTrigger:: 
+	textcolor 0
+	msgbox SilphCo_1F_Text_CriticalInfo
+	closemessage
+	applymovement OBJ_EVENT_ID_PLAYER, Movement_WalkInPlaceFastestUp
+	waitmovement 0
+	delay 20
+	compare VAR_0x8008, 1
+	call_if_eq SilphCo_1F_EventScript_PlayerWalkToCounterBottom
+	msgbox SilphCo_1F_Text_LockYouInText
+	releaseall
+	end
+
+SilphCo_1F_EventScript_PlayerWalkToCounterBottom::
+	applymovement OBJ_EVENT_ID_PLAYER, SilphCo_1F_Movement_WalkUp
+	waitmovement 0
+	return
+
+SilphCo_1F_Movement_WalkUp::
+	walk_up
+	step_end
+
+SilphCo_1F_EventScript_Scientist::
+	call_if_set FLAG_HIDE_SILPH_ROCKETS, SilphCo_1F_EventScript_PostRocketScientist
+	msgbox SilphCo_1F_Text_LockYouInText
+	end
+
+SilphCo_1F_EventScript_PostRocketScientist::
+	msgbox SilphCo_1F_Text_PostRocketScientist
+	end
+
+

--- a/data/maps/SilphCo_1F/text.inc
+++ b/data/maps/SilphCo_1F/text.inc
@@ -12,3 +12,31 @@ SilphCo_1F_Text_FloorSign:: @ 8175549
     .string "SILPH CO. HEAD OFFICE\n"
     .string "1F$"
 
+SilphCo_1F_Text_CriticalInfo::
+    .string "I have critical information!$"
+
+SilphCo_1F_Text_LockYouInText::
+    .string "TEAM ROCKET took a bunch of\n"
+    .string "SILPH CO. workers hostage and\l"
+    .string "reprogrammed our warp panels.\p"
+    .string "It appears as if this one only\n"
+    .string "goes one way, so you'll probably\l"
+    .string "be locked in until you beat them!$"
+
+SilphCo_1F_Text_PostRocketScientist::
+    .string "Thank you so much for saving us!\p"
+    .string "Unfortunately, I've realized\n"
+    .string "that I'm not as good at my job\l"
+    .string "as you are at yours.\p"
+    .string "I still haven't figured out how\n"
+    .string "to fix the warp panels, the\l"
+    .string "elevator, or anything else.$"
+
+
+
+
+
+
+
+
+

--- a/data/maps/SixIsland/map.json
+++ b/data/maps/SixIsland/map.json
@@ -15,14 +15,15 @@
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
   "connections": [
     {
-      "map": "MAP_SIX_ISLAND_WATER_PATH",
+      "direction": "right",
       "offset": -40,
-      "direction": "right"
+      "map": "MAP_SIX_ISLAND_WATER_PATH"
     }
   ],
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_BOY",
+      "in_connection": false,
       "x": 10,
       "y": 15,
       "elevation": 3,
@@ -36,6 +37,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_HIKER",
+      "in_connection": false,
       "x": 15,
       "y": 13,
       "elevation": 3,
@@ -78,7 +80,9 @@
       "dest_warp_id": 0
     }
   ],
-  "coord_events": [],
+  "coord_events": [
+
+  ],
   "bg_events": [
     {
       "type": "sign",

--- a/data/maps/SixIsland_AlteringCave/map.json
+++ b/data/maps/SixIsland_AlteringCave/map.json
@@ -13,8 +13,10 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
-  "object_events": [],
+  "connections": 0,
+  "object_events": [
+
+  ],
   "warp_events": [
     {
       "x": 18,
@@ -24,6 +26,10 @@
       "dest_warp_id": 0
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/SixIsland_DottedHole_1F/map.json
+++ b/data/maps/SixIsland_DottedHole_1F/map.json
@@ -13,8 +13,10 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
-  "object_events": [],
+  "connections": 0,
+  "object_events": [
+
+  ],
   "warp_events": [
     {
       "x": 6,
@@ -45,6 +47,10 @@
       "dest_warp_id": 2
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/SixIsland_DottedHole_B1F/map.json
+++ b/data/maps/SixIsland_DottedHole_B1F/map.json
@@ -13,8 +13,10 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
-  "object_events": [],
+  "connections": 0,
+  "object_events": [
+
+  ],
   "warp_events": [
     {
       "x": 6,
@@ -52,7 +54,9 @@
       "dest_warp_id": 3
     }
   ],
-  "coord_events": [],
+  "coord_events": [
+
+  ],
   "bg_events": [
     {
       "type": "sign",

--- a/data/maps/SixIsland_DottedHole_B2F/map.json
+++ b/data/maps/SixIsland_DottedHole_B2F/map.json
@@ -13,8 +13,10 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
-  "object_events": [],
+  "connections": 0,
+  "object_events": [
+
+  ],
   "warp_events": [
     {
       "x": 6,
@@ -52,7 +54,9 @@
       "dest_warp_id": 0
     }
   ],
-  "coord_events": [],
+  "coord_events": [
+
+  ],
   "bg_events": [
     {
       "type": "sign",

--- a/data/maps/SixIsland_DottedHole_B3F/map.json
+++ b/data/maps/SixIsland_DottedHole_B3F/map.json
@@ -13,8 +13,10 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
-  "object_events": [],
+  "connections": 0,
+  "object_events": [
+
+  ],
   "warp_events": [
     {
       "x": 6,
@@ -52,7 +54,9 @@
       "dest_warp_id": 3
     }
   ],
-  "coord_events": [],
+  "coord_events": [
+
+  ],
   "bg_events": [
     {
       "type": "sign",

--- a/data/maps/SixIsland_DottedHole_B4F/map.json
+++ b/data/maps/SixIsland_DottedHole_B4F/map.json
@@ -13,8 +13,10 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
-  "object_events": [],
+  "connections": 0,
+  "object_events": [
+
+  ],
   "warp_events": [
     {
       "x": 6,
@@ -52,7 +54,9 @@
       "dest_warp_id": 3
     }
   ],
-  "coord_events": [],
+  "coord_events": [
+
+  ],
   "bg_events": [
     {
       "type": "sign",

--- a/data/maps/SixIsland_DottedHole_SapphireRoom/map.json
+++ b/data/maps/SixIsland_DottedHole_SapphireRoom/map.json
@@ -13,10 +13,11 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
+  "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_SAPPHIRE",
+      "in_connection": false,
       "x": 7,
       "y": 7,
       "elevation": 0,
@@ -30,6 +31,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_SCIENTIST",
+      "in_connection": false,
       "x": 5,
       "y": 9,
       "elevation": 3,
@@ -58,7 +60,9 @@
       "dest_warp_id": 3
     }
   ],
-  "coord_events": [],
+  "coord_events": [
+
+  ],
   "bg_events": [
     {
       "type": "sign",

--- a/data/maps/SixIsland_GreenPath/map.json
+++ b/data/maps/SixIsland_GreenPath/map.json
@@ -15,19 +15,20 @@
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
   "connections": [
     {
-      "map": "MAP_SIX_ISLAND_OUTCAST_ISLAND",
+      "direction": "up",
       "offset": 0,
-      "direction": "up"
+      "map": "MAP_SIX_ISLAND_OUTCAST_ISLAND"
     },
     {
-      "map": "MAP_SIX_ISLAND_WATER_PATH",
+      "direction": "right",
       "offset": 0,
-      "direction": "right"
+      "map": "MAP_SIX_ISLAND_WATER_PATH"
     }
   ],
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_WOMAN_1",
+      "in_connection": false,
       "x": 11,
       "y": 8,
       "elevation": 3,
@@ -70,7 +71,9 @@
       "dest_warp_id": 4
     }
   ],
-  "coord_events": [],
+  "coord_events": [
+
+  ],
   "bg_events": [
     {
       "type": "sign",

--- a/data/maps/SixIsland_OutcastIsland/map.json
+++ b/data/maps/SixIsland_OutcastIsland/map.json
@@ -15,14 +15,15 @@
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
   "connections": [
     {
-      "map": "MAP_SIX_ISLAND_GREEN_PATH",
+      "direction": "down",
       "offset": 0,
-      "direction": "down"
+      "map": "MAP_SIX_ISLAND_GREEN_PATH"
     }
   ],
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKET_M",
+      "in_connection": false,
       "x": 9,
       "y": 24,
       "elevation": 3,
@@ -36,6 +37,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_FISHER",
+      "in_connection": false,
       "x": 12,
       "y": 15,
       "elevation": 3,
@@ -49,6 +51,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_SWIMMER_M_WATER",
+      "in_connection": false,
       "x": 13,
       "y": 34,
       "elevation": 1,
@@ -62,6 +65,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_SWIMMER_F_WATER",
+      "in_connection": false,
       "x": 14,
       "y": 61,
       "elevation": 1,
@@ -75,6 +79,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_SWIMMER_F_WATER",
+      "in_connection": false,
       "x": 10,
       "y": 44,
       "elevation": 1,
@@ -88,6 +93,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_TUBER_M_WATER",
+      "in_connection": false,
       "x": 11,
       "y": 44,
       "elevation": 1,
@@ -101,6 +107,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 11,
       "y": 16,
       "elevation": 3,
@@ -122,7 +129,9 @@
       "dest_warp_id": 0
     }
   ],
-  "coord_events": [],
+  "coord_events": [
+
+  ],
   "bg_events": [
     {
       "type": "hidden_item",

--- a/data/maps/SixIsland_PatternBush/map.json
+++ b/data/maps/SixIsland_PatternBush/map.json
@@ -13,10 +13,11 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
+  "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_WOMAN_2",
+      "in_connection": false,
       "x": 48,
       "y": 15,
       "elevation": 3,
@@ -30,6 +31,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_WOMAN_2",
+      "in_connection": false,
       "x": 10,
       "y": 5,
       "elevation": 3,
@@ -43,6 +45,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BUG_CATCHER",
+      "in_connection": false,
       "x": 51,
       "y": 6,
       "elevation": 3,
@@ -56,6 +59,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BUG_CATCHER",
+      "in_connection": false,
       "x": 12,
       "y": 13,
       "elevation": 3,
@@ -69,6 +73,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_BUG_CATCHER",
+      "in_connection": false,
       "x": 37,
       "y": 23,
       "elevation": 3,
@@ -82,6 +87,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_YOUNGSTER",
+      "in_connection": false,
       "x": 32,
       "y": 5,
       "elevation": 3,
@@ -95,6 +101,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_YOUNGSTER",
+      "in_connection": false,
       "x": 52,
       "y": 20,
       "elevation": 3,
@@ -108,6 +115,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_LASS",
+      "in_connection": false,
       "x": 8,
       "y": 21,
       "elevation": 3,
@@ -121,6 +129,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_LASS",
+      "in_connection": false,
       "x": 39,
       "y": 6,
       "elevation": 3,
@@ -134,6 +143,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_CAMPER",
+      "in_connection": false,
       "x": 3,
       "y": 9,
       "elevation": 3,
@@ -147,6 +157,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PICNICKER",
+      "in_connection": false,
       "x": 19,
       "y": 24,
       "elevation": 3,
@@ -160,6 +171,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_HIKER",
+      "in_connection": false,
       "x": 30,
       "y": 19,
       "elevation": 3,
@@ -216,6 +228,10 @@
       "dest_warp_id": 3
     }
   ],
-  "coord_events": [],
-  "bg_events": []
+  "coord_events": [
+
+  ],
+  "bg_events": [
+
+  ]
 }

--- a/data/maps/SixIsland_RuinValley/map.json
+++ b/data/maps/SixIsland_RuinValley/map.json
@@ -15,14 +15,15 @@
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
   "connections": [
     {
-      "map": "MAP_SIX_ISLAND_WATER_PATH",
+      "direction": "right",
       "offset": -80,
-      "direction": "right"
+      "map": "MAP_SIX_ISLAND_WATER_PATH"
     }
   ],
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_SCIENTIST",
+      "in_connection": false,
       "x": 24,
       "y": 25,
       "elevation": 3,
@@ -36,6 +37,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_HIKER",
+      "in_connection": false,
       "x": 32,
       "y": 11,
       "elevation": 5,
@@ -49,6 +51,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_HIKER",
+      "in_connection": false,
       "x": 33,
       "y": 16,
       "elevation": 5,
@@ -62,6 +65,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_HIKER",
+      "in_connection": false,
       "x": 31,
       "y": 24,
       "elevation": 5,
@@ -75,6 +79,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_HIKER",
+      "in_connection": false,
       "x": 14,
       "y": 10,
       "elevation": 5,
@@ -88,6 +93,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_SUPER_NERD",
+      "in_connection": false,
       "x": 21,
       "y": 29,
       "elevation": 5,
@@ -101,6 +107,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
+      "in_connection": false,
       "x": 17,
       "y": 10,
       "elevation": 5,
@@ -114,6 +121,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
+      "in_connection": false,
       "x": 17,
       "y": 12,
       "elevation": 5,
@@ -127,6 +135,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
+      "in_connection": false,
       "x": 18,
       "y": 11,
       "elevation": 5,
@@ -140,6 +149,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
+      "in_connection": false,
       "x": 6,
       "y": 33,
       "elevation": 3,
@@ -153,6 +163,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
+      "in_connection": false,
       "x": 6,
       "y": 34,
       "elevation": 3,
@@ -166,6 +177,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
+      "in_connection": false,
       "x": 41,
       "y": 32,
       "elevation": 3,
@@ -179,6 +191,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
+      "in_connection": false,
       "x": 41,
       "y": 33,
       "elevation": 3,
@@ -192,6 +205,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
+      "in_connection": false,
       "x": 42,
       "y": 33,
       "elevation": 3,
@@ -205,19 +219,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "x": 5,
-      "y": 33,
-      "elevation": 3,
-      "movement_type": "MOVEMENT_TYPE_FACE_DOWN",
-      "movement_range_x": 1,
-      "movement_range_y": 1,
-      "trainer_type": "TRAINER_TYPE_NONE",
-      "trainer_sight_or_berry_tree_id": "0",
-      "script": "SixIsland_RuinValley_EventScript_ItemHPUp",
-      "flag": "FLAG_HIDE_SIX_ISLAND_RUIN_VALLEY_HP_UP"
-    },
-    {
-      "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 19,
       "y": 11,
       "elevation": 5,
@@ -231,6 +233,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 43,
       "y": 32,
       "elevation": 3,
@@ -252,7 +255,9 @@
       "dest_warp_id": 0
     }
   ],
-  "coord_events": [],
+  "coord_events": [
+
+  ],
   "bg_events": [
     {
       "type": "sign",

--- a/data/maps/SixIsland_WaterPath/map.json
+++ b/data/maps/SixIsland_WaterPath/map.json
@@ -15,24 +15,25 @@
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
   "connections": [
     {
-      "map": "MAP_SIX_ISLAND_GREEN_PATH",
+      "direction": "left",
       "offset": 0,
-      "direction": "left"
+      "map": "MAP_SIX_ISLAND_GREEN_PATH"
     },
     {
-      "map": "MAP_SIX_ISLAND",
+      "direction": "left",
       "offset": 40,
-      "direction": "left"
+      "map": "MAP_SIX_ISLAND"
     },
     {
-      "map": "MAP_SIX_ISLAND_RUIN_VALLEY",
+      "direction": "left",
       "offset": 80,
-      "direction": "left"
+      "map": "MAP_SIX_ISLAND_RUIN_VALLEY"
     }
   ],
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_WOMAN_2",
+      "in_connection": false,
       "x": 12,
       "y": 13,
       "elevation": 3,
@@ -46,6 +47,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ROCKER",
+      "in_connection": false,
       "x": 11,
       "y": 52,
       "elevation": 3,
@@ -59,6 +61,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_SWIMMER_M_WATER",
+      "in_connection": false,
       "x": 13,
       "y": 35,
       "elevation": 1,
@@ -72,6 +75,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_SWIMMER_F_WATER",
+      "in_connection": false,
       "x": 15,
       "y": 45,
       "elevation": 1,
@@ -85,6 +89,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_LITTLE_GIRL",
+      "in_connection": false,
       "x": 6,
       "y": 21,
       "elevation": 3,
@@ -98,6 +103,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_LITTLE_GIRL",
+      "in_connection": false,
       "x": 7,
       "y": 21,
       "elevation": 3,
@@ -111,6 +117,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_HIKER",
+      "in_connection": false,
       "x": 11,
       "y": 76,
       "elevation": 3,
@@ -124,19 +131,7 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
-      "x": 17,
-      "y": 19,
-      "elevation": 0,
-      "movement_type": "MOVEMENT_TYPE_FACE_DOWN",
-      "movement_range_x": 1,
-      "movement_range_y": 1,
-      "trainer_type": "TRAINER_TYPE_NONE",
-      "trainer_sight_or_berry_tree_id": "0",
-      "script": "SixIsland_WaterPath_EventScript_ItemElixir",
-      "flag": "FLAG_HIDE_SIX_ISLAND_WATER_PATH_ELIXIR"
-    },
-    {
-      "graphics_id": "OBJ_EVENT_GFX_ITEM_BALL",
+      "in_connection": false,
       "x": 17,
       "y": 87,
       "elevation": 3,
@@ -165,7 +160,9 @@
       "dest_warp_id": 0
     }
   ],
-  "coord_events": [],
+  "coord_events": [
+
+  ],
   "bg_events": [
     {
       "type": "sign",

--- a/data/maps/ThreeIsland_DunsparceTunnel/map.json
+++ b/data/maps/ThreeIsland_DunsparceTunnel/map.json
@@ -13,10 +13,11 @@
   "show_map_name": true,
   "floor_number": 0,
   "battle_scene": "MAP_BATTLE_SCENE_NORMAL",
-  "connections": null,
+  "connections": 0,
   "object_events": [
     {
       "graphics_id": "OBJ_EVENT_GFX_FAT_MAN",
+      "in_connection": false,
       "x": 23,
       "y": 2,
       "elevation": 3,
@@ -45,7 +46,9 @@
       "dest_warp_id": 1
     }
   ],
-  "coord_events": [],
+  "coord_events": [
+
+  ],
   "bg_events": [
     {
       "type": "hidden_item",

--- a/src/data/wild_encounters.json
+++ b/src/data/wild_encounters.json
@@ -717,6 +717,31 @@
         {
           "map": "MAP_SSANNE_EXTERIOR",
           "base_label": "sSSAnneExterior_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 1,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 10,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 10,
+                "max_level": 20,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              }
+            ]
+          },
           "fishing_mons": {
             "encounter_rate": 10,
             "mons": [
@@ -748,31 +773,6 @@
               {
                 "min_level": 15,
                 "max_level": 25,
-                "species": "SPECIES_FEEBAS"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 1,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 10,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 10,
-                "max_level": 20,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
                 "species": "SPECIES_FEEBAS"
               }
             ]
@@ -1253,6 +1253,31 @@
         {
           "map": "MAP_SAFARI_ZONE_CENTER",
           "base_label": "sSafariZoneCenter_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 20,
+                "max_level": 25,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 20,
+                "max_level": 25,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              }
+            ]
+          },
           "land_mons": {
             "encounter_rate": 21,
             "mons": [
@@ -1340,31 +1365,6 @@
                 "min_level": 15,
                 "max_level": 25,
                 "species": "SPECIES_MAGIKARP"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 20,
-                "max_level": 25,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 20,
-                "max_level": 25,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
               }
             ]
           }
@@ -1372,6 +1372,31 @@
         {
           "map": "MAP_SAFARI_ZONE_EAST",
           "base_label": "sSafariZoneEast_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 20,
+                "max_level": 25,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 20,
+                "max_level": 25,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              }
+            ]
+          },
           "land_mons": {
             "encounter_rate": 21,
             "mons": [
@@ -1458,31 +1483,6 @@
               {
                 "min_level": 15,
                 "max_level": 25,
-                "species": "SPECIES_FEEBAS"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 20,
-                "max_level": 25,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 20,
-                "max_level": 25,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
                 "species": "SPECIES_FEEBAS"
               }
             ]
@@ -1491,6 +1491,31 @@
         {
           "map": "MAP_SAFARI_ZONE_NORTH",
           "base_label": "sSafariZoneNorth_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 20,
+                "max_level": 25,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 20,
+                "max_level": 25,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              }
+            ]
+          },
           "land_mons": {
             "encounter_rate": 21,
             "mons": [
@@ -1578,31 +1603,6 @@
                 "min_level": 15,
                 "max_level": 25,
                 "species": "SPECIES_MAGIKARP"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 20,
-                "max_level": 25,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 20,
-                "max_level": 25,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
               }
             ]
           }
@@ -1610,6 +1610,31 @@
         {
           "map": "MAP_SAFARI_ZONE_WEST",
           "base_label": "sSafariZoneWest_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 20,
+                "max_level": 25,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 20,
+                "max_level": 25,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              }
+            ]
+          },
           "land_mons": {
             "encounter_rate": 21,
             "mons": [
@@ -1696,31 +1721,6 @@
               {
                 "min_level": 15,
                 "max_level": 25,
-                "species": "SPECIES_FEEBAS"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 20,
-                "max_level": 25,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 20,
-                "max_level": 25,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
                 "species": "SPECIES_FEEBAS"
               }
             ]
@@ -1729,13 +1729,38 @@
         {
           "map": "MAP_CERULEAN_CAVE_1F",
           "base_label": "sCeruleanCave1F_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 30,
+                "max_level": 40,
+                "species": "SPECIES_PSYDUCK"
+              },
+              {
+                "min_level": 40,
+                "max_level": 50,
+                "species": "SPECIES_GOLDUCK"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              }
+            ]
+          },
           "land_mons": {
             "encounter_rate": 7,
             "mons": [
               {
                 "min_level": 49,
                 "max_level": 49,
-                "species": "SPECIES_MAGNETON"
+                "species": "SPECIES_MAGNEMITE"
               },
               {
                 "min_level": 49,
@@ -1755,7 +1780,7 @@
               {
                 "min_level": 52,
                 "max_level": 52,
-                "species": "SPECIES_PRIMEAPE"
+                "species": "SPECIES_MANKEY"
               },
               {
                 "min_level": 52,
@@ -1780,7 +1805,37 @@
               {
                 "min_level": 55,
                 "max_level": 55,
-                "species": "SPECIES_WOBBUFFET"
+                "species": "SPECIES_WYNAUT"
+              }
+            ]
+          },
+          "rock_smash_mons": {
+            "encounter_rate": 50,
+            "mons": [
+              {
+                "min_level": 30,
+                "max_level": 40,
+                "species": "SPECIES_GEODUDE"
+              },
+              {
+                "min_level": 40,
+                "max_level": 50,
+                "species": "SPECIES_GRAVELER"
+              },
+              {
+                "min_level": 45,
+                "max_level": 55,
+                "species": "SPECIES_GRAVELER"
+              },
+              {
+                "min_level": 40,
+                "max_level": 50,
+                "species": "SPECIES_GEODUDE"
+              },
+              {
+                "min_level": 40,
+                "max_level": 50,
+                "species": "SPECIES_GEODUDE"
               }
             ]
           },
@@ -1818,61 +1873,6 @@
                 "species": "SPECIES_POLIWAG"
               }
             ]
-          },
-          "rock_smash_mons": {
-            "encounter_rate": 50,
-            "mons": [
-              {
-                "min_level": 30,
-                "max_level": 40,
-                "species": "SPECIES_GEODUDE"
-              },
-              {
-                "min_level": 40,
-                "max_level": 50,
-                "species": "SPECIES_GRAVELER"
-              },
-              {
-                "min_level": 45,
-                "max_level": 55,
-                "species": "SPECIES_GRAVELER"
-              },
-              {
-                "min_level": 40,
-                "max_level": 50,
-                "species": "SPECIES_GEODUDE"
-              },
-              {
-                "min_level": 40,
-                "max_level": 50,
-                "species": "SPECIES_GEODUDE"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 30,
-                "max_level": 40,
-                "species": "SPECIES_PSYDUCK"
-              },
-              {
-                "min_level": 40,
-                "max_level": 50,
-                "species": "SPECIES_GOLDUCK"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_NONE"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_NONE"
-              }
-            ]
           }
         },
         {
@@ -1894,7 +1894,7 @@
               {
                 "min_level": 52,
                 "max_level": 52,
-                "species": "SPECIES_MAGNETON"
+                "species": "SPECIES_MAGNEMITE"
               },
               {
                 "min_level": 52,
@@ -1904,7 +1904,7 @@
               {
                 "min_level": 55,
                 "max_level": 55,
-                "species": "SPECIES_KADABRA"
+                "species": "SPECIES_ABRA"
               },
               {
                 "min_level": 55,
@@ -1919,7 +1919,7 @@
               {
                 "min_level": 58,
                 "max_level": 58,
-                "species": "SPECIES_WOBBUFFET"
+                "species": "SPECIES_WYNAUT"
               },
               {
                 "min_level": 61,
@@ -1967,13 +1967,38 @@
         {
           "map": "MAP_CERULEAN_CAVE_B1F",
           "base_label": "sCeruleanCaveB1F_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 40,
+                "max_level": 50,
+                "species": "SPECIES_PSYDUCK"
+              },
+              {
+                "min_level": 50,
+                "max_level": 60,
+                "species": "SPECIES_GOLDUCK"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_MAGIKARP"
+              }
+            ]
+          },
           "land_mons": {
             "encounter_rate": 7,
             "mons": [
               {
                 "min_level": 58,
                 "max_level": 58,
-                "species": "SPECIES_KADABRA"
+                "species": "SPECIES_ABRA"
               },
               {
                 "min_level": 58,
@@ -1983,7 +2008,7 @@
               {
                 "min_level": 55,
                 "max_level": 55,
-                "species": "SPECIES_MAGNETON"
+                "species": "SPECIES_MAGNEMITE"
               },
               {
                 "min_level": 55,
@@ -2003,7 +2028,7 @@
               {
                 "min_level": 67,
                 "max_level": 67,
-                "species": "SPECIES_KADABRA"
+                "species": "SPECIES_ABRA"
               },
               {
                 "min_level": 67,
@@ -2019,6 +2044,36 @@
                 "min_level": 64,
                 "max_level": 64,
                 "species": "SPECIES_PARASECT"
+              }
+            ]
+          },
+          "rock_smash_mons": {
+            "encounter_rate": 50,
+            "mons": [
+              {
+                "min_level": 40,
+                "max_level": 50,
+                "species": "SPECIES_GEODUDE"
+              },
+              {
+                "min_level": 50,
+                "max_level": 60,
+                "species": "SPECIES_GRAVELER"
+              },
+              {
+                "min_level": 55,
+                "max_level": 65,
+                "species": "SPECIES_GRAVELER"
+              },
+              {
+                "min_level": 50,
+                "max_level": 60,
+                "species": "SPECIES_GEODUDE"
+              },
+              {
+                "min_level": 50,
+                "max_level": 60,
+                "species": "SPECIES_GEODUDE"
               }
             ]
           },
@@ -2054,61 +2109,6 @@
                 "min_level": 15,
                 "max_level": 25,
                 "species": "SPECIES_POLIWAG"
-              }
-            ]
-          },
-          "rock_smash_mons": {
-            "encounter_rate": 50,
-            "mons": [
-              {
-                "min_level": 40,
-                "max_level": 50,
-                "species": "SPECIES_GEODUDE"
-              },
-              {
-                "min_level": 50,
-                "max_level": 60,
-                "species": "SPECIES_GRAVELER"
-              },
-              {
-                "min_level": 55,
-                "max_level": 65,
-                "species": "SPECIES_GRAVELER"
-              },
-              {
-                "min_level": 50,
-                "max_level": 60,
-                "species": "SPECIES_GEODUDE"
-              },
-              {
-                "min_level": 50,
-                "max_level": 60,
-                "species": "SPECIES_GEODUDE"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 40,
-                "max_level": 50,
-                "species": "SPECIES_PSYDUCK"
-              },
-              {
-                "min_level": 50,
-                "max_level": 60,
-                "species": "SPECIES_GOLDUCK"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_NONE"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_NONE"
               }
             ]
           }
@@ -2441,6 +2441,31 @@
         {
           "map": "MAP_SEAFOAM_ISLANDS_B3F",
           "base_label": "sSeafoamIslandsB3F_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 25,
+                "max_level": 35,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 25,
+                "max_level": 30,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              }
+            ]
+          },
           "land_mons": {
             "encounter_rate": 7,
             "mons": [
@@ -2528,31 +2553,6 @@
                 "min_level": 15,
                 "max_level": 25,
                 "species": "SPECIES_MAGIKARP"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 25,
-                "max_level": 35,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 25,
-                "max_level": 30,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
               }
             ]
           }
@@ -2560,6 +2560,31 @@
         {
           "map": "MAP_SEAFOAM_ISLANDS_B4F",
           "base_label": "sSeafoamIslandsB4F_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 25,
+                "max_level": 35,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 25,
+                "max_level": 30,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              }
+            ]
+          },
           "land_mons": {
             "encounter_rate": 7,
             "mons": [
@@ -2646,31 +2671,6 @@
               {
                 "min_level": 15,
                 "max_level": 25,
-                "species": "SPECIES_FEEBAS"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 25,
-                "max_level": 35,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 25,
-                "max_level": 30,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
                 "species": "SPECIES_FEEBAS"
               }
             ]
@@ -3863,6 +3863,31 @@
         {
           "map": "MAP_THREE_ISLAND_BERRY_FOREST",
           "base_label": "sThreeIslandBerryForest_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 20,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 20,
+                "max_level": 35,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              }
+            ]
+          },
           "land_mons": {
             "encounter_rate": 21,
             "mons": [
@@ -3952,36 +3977,36 @@
                 "species": "SPECIES_MAGIKARP"
               }
             ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 20,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 20,
-                "max_level": 35,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
-              }
-            ]
           }
         },
         {
           "map": "MAP_FOUR_ISLAND_ICEFALL_CAVE_ENTRANCE",
           "base_label": "sFourIslandIcefallCaveEntrance_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 35,
+                "species": "SPECIES_SEEL"
+              },
+              {
+                "min_level": 5,
+                "max_level": 35,
+                "species": "SPECIES_PSYDUCK"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_PSYDUCK"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_PSYDUCK"
+              }
+            ]
+          },
           "land_mons": {
             "encounter_rate": 7,
             "mons": [
@@ -4013,12 +4038,12 @@
               {
                 "min_level": 49,
                 "max_level": 49,
-                "species": "SPECIES_DEWGONG"
+                "species": "SPECIES_SPHEAL"
               },
               {
                 "min_level": 51,
                 "max_level": 51,
-                "species": "SPECIES_DEWGONG"
+                "species": "SPECIES_SPHEAL"
               },
               {
                 "min_level": 41,
@@ -4033,7 +4058,7 @@
               {
                 "min_level": 53,
                 "max_level": 53,
-                "species": "SPECIES_DEWGONG"
+                "species": "SPECIES_SPHEAL"
               }
             ]
           },
@@ -4069,31 +4094,6 @@
                 "min_level": 15,
                 "max_level": 25,
                 "species": "SPECIES_POLIWAG"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 35,
-                "species": "SPECIES_SEEL"
-              },
-              {
-                "min_level": 5,
-                "max_level": 35,
-                "species": "SPECIES_PSYDUCK"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_PSYDUCK"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_PSYDUCK"
               }
             ]
           }
@@ -4219,6 +4219,31 @@
         {
           "map": "MAP_FOUR_ISLAND_ICEFALL_CAVE_BACK",
           "base_label": "sFourIslandIcefallCaveBack_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 20,
+                "species": "SPECIES_TENTACOOL"
+              },
+              {
+                "min_level": 20,
+                "max_level": 35,
+                "species": "SPECIES_TENTACOOL"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_TENTACOOL"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_TENTACOOL"
+              }
+            ]
+          },
           "land_mons": {
             "encounter_rate": 7,
             "mons": [
@@ -4250,12 +4275,12 @@
               {
                 "min_level": 49,
                 "max_level": 49,
-                "species": "SPECIES_DEWGONG"
+                "species": "SPECIES_DELIBIRD"
               },
               {
                 "min_level": 51,
                 "max_level": 51,
-                "species": "SPECIES_DEWGONG"
+                "species": "SPECIES_DELIBIRD"
               },
               {
                 "min_level": 41,
@@ -4270,7 +4295,7 @@
               {
                 "min_level": 53,
                 "max_level": 53,
-                "species": "SPECIES_DEWGONG"
+                "species": "SPECIES_DELIBIRD"
               }
             ]
           },
@@ -4306,31 +4331,6 @@
                 "min_level": 15,
                 "max_level": 25,
                 "species": "SPECIES_HORSEA"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 20,
-                "species": "SPECIES_TENTACOOL"
-              },
-              {
-                "min_level": 20,
-                "max_level": 35,
-                "species": "SPECIES_TENTACOOL"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_TENTACOOL"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_TENTACOOL"
               }
             ]
           }
@@ -4369,7 +4369,7 @@
               {
                 "min_level": 15,
                 "max_level": 15,
-                "species": "SPECIES_HERACROSS"
+                "species": "SPECIES_LEDYBA"
               },
               {
                 "min_level": 9,
@@ -4379,7 +4379,7 @@
               {
                 "min_level": 20,
                 "max_level": 20,
-                "species": "SPECIES_HERACROSS"
+                "species": "SPECIES_LEDYBA"
               },
               {
                 "min_level": 9,
@@ -4389,7 +4389,7 @@
               {
                 "min_level": 25,
                 "max_level": 25,
-                "species": "SPECIES_HERACROSS"
+                "species": "SPECIES_LEDYBA"
               }
             ]
           }
@@ -4413,12 +4413,12 @@
               {
                 "min_level": 44,
                 "max_level": 44,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 46,
                 "max_level": 46,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 41,
@@ -4438,12 +4438,12 @@
               {
                 "min_level": 48,
                 "max_level": 48,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 50,
                 "max_level": 50,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 22,
@@ -4472,12 +4472,12 @@
               {
                 "min_level": 44,
                 "max_level": 44,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 46,
                 "max_level": 46,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 41,
@@ -4497,12 +4497,12 @@
               {
                 "min_level": 48,
                 "max_level": 48,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 50,
                 "max_level": 50,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 22,
@@ -4531,12 +4531,12 @@
               {
                 "min_level": 44,
                 "max_level": 44,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 46,
                 "max_level": 46,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 41,
@@ -4556,12 +4556,12 @@
               {
                 "min_level": 48,
                 "max_level": 48,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 50,
                 "max_level": 50,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 22,
@@ -4590,12 +4590,12 @@
               {
                 "min_level": 44,
                 "max_level": 44,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 46,
                 "max_level": 46,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 41,
@@ -4615,12 +4615,12 @@
               {
                 "min_level": 48,
                 "max_level": 48,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 50,
                 "max_level": 50,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 22,
@@ -4649,12 +4649,12 @@
               {
                 "min_level": 44,
                 "max_level": 44,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 46,
                 "max_level": 46,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 41,
@@ -4674,12 +4674,12 @@
               {
                 "min_level": 48,
                 "max_level": 48,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 50,
                 "max_level": 50,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 22,
@@ -4708,12 +4708,12 @@
               {
                 "min_level": 44,
                 "max_level": 44,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 46,
                 "max_level": 46,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 41,
@@ -4733,12 +4733,12 @@
               {
                 "min_level": 48,
                 "max_level": 48,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 50,
                 "max_level": 50,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 22,
@@ -4767,12 +4767,12 @@
               {
                 "min_level": 44,
                 "max_level": 44,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 46,
                 "max_level": 46,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 41,
@@ -4792,12 +4792,12 @@
               {
                 "min_level": 48,
                 "max_level": 48,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 50,
                 "max_level": 50,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 22,
@@ -4826,12 +4826,12 @@
               {
                 "min_level": 44,
                 "max_level": 44,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 46,
                 "max_level": 46,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 41,
@@ -4851,12 +4851,12 @@
               {
                 "min_level": 48,
                 "max_level": 48,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 50,
                 "max_level": 50,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 22,
@@ -4885,12 +4885,12 @@
               {
                 "min_level": 44,
                 "max_level": 44,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 46,
                 "max_level": 46,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 41,
@@ -4910,12 +4910,12 @@
               {
                 "min_level": 48,
                 "max_level": 48,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 50,
                 "max_level": 50,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 22,
@@ -4944,12 +4944,12 @@
               {
                 "min_level": 44,
                 "max_level": 44,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 46,
                 "max_level": 46,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 41,
@@ -4969,12 +4969,12 @@
               {
                 "min_level": 48,
                 "max_level": 48,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 50,
                 "max_level": 50,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 22,
@@ -5003,12 +5003,12 @@
               {
                 "min_level": 44,
                 "max_level": 44,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 46,
                 "max_level": 46,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 41,
@@ -5028,12 +5028,12 @@
               {
                 "min_level": 48,
                 "max_level": 48,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 50,
                 "max_level": 50,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 22,
@@ -5062,12 +5062,12 @@
               {
                 "min_level": 44,
                 "max_level": 44,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 46,
                 "max_level": 46,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 41,
@@ -5087,12 +5087,12 @@
               {
                 "min_level": 48,
                 "max_level": 48,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 50,
                 "max_level": 50,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 22,
@@ -5121,12 +5121,12 @@
               {
                 "min_level": 44,
                 "max_level": 44,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 46,
                 "max_level": 46,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 41,
@@ -5146,12 +5146,12 @@
               {
                 "min_level": 48,
                 "max_level": 48,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 50,
                 "max_level": 50,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 22,
@@ -5180,12 +5180,12 @@
               {
                 "min_level": 44,
                 "max_level": 44,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 46,
                 "max_level": 46,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 41,
@@ -5205,12 +5205,12 @@
               {
                 "min_level": 48,
                 "max_level": 48,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 50,
                 "max_level": 50,
-                "species": "SPECIES_HAUNTER"
+                "species": "SPECIES_SHUPPET"
               },
               {
                 "min_level": 22,
@@ -5223,6 +5223,31 @@
         {
           "map": "MAP_ONE_ISLAND_KINDLE_ROAD",
           "base_label": "sOneIslandKindleRoad_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 20,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 20,
+                "max_level": 35,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_MAGIKARP"
+              }
+            ]
+          },
           "land_mons": {
             "encounter_rate": 21,
             "mons": [
@@ -5275,41 +5300,6 @@
                 "min_level": 45,
                 "max_level": 46,
                 "species": "SPECIES_SANDSLASH"
-              }
-            ]
-          },
-          "fishing_mons": {
-            "encounter_rate": 20,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 15,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 15,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 15,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 15,
-                "max_level": 25,
-                "species": "SPECIES_MAGIKARP"
               }
             ]
           },
@@ -5343,19 +5333,9 @@
               }
             ]
           },
-          "water_mons": {
-            "encounter_rate": 2,
+          "fishing_mons": {
+            "encounter_rate": 20,
             "mons": [
-              {
-                "min_level": 5,
-                "max_level": 20,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 20,
-                "max_level": 35,
-                "species": "SPECIES_FEEBAS"
-              },
               {
                 "min_level": 5,
                 "max_level": 5,
@@ -5364,6 +5344,26 @@
               {
                 "min_level": 5,
                 "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 15,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 15,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 15,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 15,
+                "max_level": 25,
                 "species": "SPECIES_MAGIKARP"
               }
             ]
@@ -5372,6 +5372,31 @@
         {
           "map": "MAP_ONE_ISLAND_TREASURE_BEACH",
           "base_label": "sOneIslandTreasureBeach_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 20,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 20,
+                "max_level": 35,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              }
+            ]
+          },
           "land_mons": {
             "encounter_rate": 21,
             "mons": [
@@ -5458,31 +5483,6 @@
               {
                 "min_level": 15,
                 "max_level": 25,
-                "species": "SPECIES_FEEBAS"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 20,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 20,
-                "max_level": 35,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
                 "species": "SPECIES_FEEBAS"
               }
             ]
@@ -5491,6 +5491,31 @@
         {
           "map": "MAP_TWO_ISLAND_CAPE_BRINK",
           "base_label": "sTwoIslandCapeBrink_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 20,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 20,
+                "max_level": 35,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              }
+            ]
+          },
           "land_mons": {
             "encounter_rate": 21,
             "mons": [
@@ -5578,31 +5603,6 @@
                 "min_level": 15,
                 "max_level": 25,
                 "species": "SPECIES_MAGIKARP"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 20,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 20,
-                "max_level": 35,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
               }
             ]
           }
@@ -5610,6 +5610,31 @@
         {
           "map": "MAP_THREE_ISLAND_BOND_BRIDGE",
           "base_label": "sThreeIslandBondBridge_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 20,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 20,
+                "max_level": 35,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              }
+            ]
+          },
           "land_mons": {
             "encounter_rate": 21,
             "mons": [
@@ -5697,31 +5722,6 @@
                 "min_level": 15,
                 "max_level": 25,
                 "species": "SPECIES_MAGIKARP"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 20,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 20,
-                "max_level": 35,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
               }
             ]
           }
@@ -5788,41 +5788,6 @@
         {
           "map": "MAP_FIVE_ISLAND_RESORT_GORGEOUS",
           "base_label": "sFiveIslandResortGorgeous_LeafGreen",
-          "fishing_mons": {
-            "encounter_rate": 20,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 15,
-                "species": "SPECIES_HORSEA"
-              },
-              {
-                "min_level": 5,
-                "max_level": 15,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 15,
-                "species": "SPECIES_HORSEA"
-              },
-              {
-                "min_level": 15,
-                "max_level": 25,
-                "species": "SPECIES_HORSEA"
-              }
-            ]
-          },
           "water_mons": {
             "encounter_rate": 2,
             "mons": [
@@ -5847,11 +5812,7 @@
                 "species": "SPECIES_HOPPIP"
               }
             ]
-          }
-        },
-        {
-          "map": "MAP_FIVE_ISLAND_WATER_LABYRINTH",
-          "base_label": "sFiveIslandWaterLabyrinth_LeafGreen",
+          },
           "fishing_mons": {
             "encounter_rate": 20,
             "mons": [
@@ -5886,7 +5847,11 @@
                 "species": "SPECIES_HORSEA"
               }
             ]
-          },
+          }
+        },
+        {
+          "map": "MAP_FIVE_ISLAND_WATER_LABYRINTH",
+          "base_label": "sFiveIslandWaterLabyrinth_LeafGreen",
           "water_mons": {
             "encounter_rate": 2,
             "mons": [
@@ -5911,11 +5876,71 @@
                 "species": "SPECIES_HOPPIP"
               }
             ]
+          },
+          "fishing_mons": {
+            "encounter_rate": 20,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 15,
+                "species": "SPECIES_HORSEA"
+              },
+              {
+                "min_level": 5,
+                "max_level": 15,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 15,
+                "species": "SPECIES_HORSEA"
+              },
+              {
+                "min_level": 15,
+                "max_level": 25,
+                "species": "SPECIES_HORSEA"
+              }
+            ]
           }
         },
         {
           "map": "MAP_FIVE_ISLAND_MEADOW",
           "base_label": "sFiveIslandMeadow_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 35,
+                "species": "SPECIES_TENTACOOL"
+              },
+              {
+                "min_level": 5,
+                "max_level": 15,
+                "species": "SPECIES_HOPPIP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_HOPPIP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_HOPPIP"
+              }
+            ]
+          },
           "land_mons": {
             "encounter_rate": 21,
             "mons": [
@@ -6005,7 +6030,11 @@
                 "species": "SPECIES_HORSEA"
               }
             ]
-          },
+          }
+        },
+        {
+          "map": "MAP_FIVE_ISLAND_MEMORIAL_PILLAR",
+          "base_label": "sFiveIslandMemorialPillar_LeafGreen",
           "water_mons": {
             "encounter_rate": 2,
             "mons": [
@@ -6030,11 +6059,7 @@
                 "species": "SPECIES_HOPPIP"
               }
             ]
-          }
-        },
-        {
-          "map": "MAP_FIVE_ISLAND_MEMORIAL_PILLAR",
-          "base_label": "sFiveIslandMemorialPillar_LeafGreen",
+          },
           "land_mons": {
             "encounter_rate": 21,
             "mons": [
@@ -6124,19 +6149,23 @@
                 "species": "SPECIES_HORSEA"
               }
             ]
-          },
+          }
+        },
+        {
+          "map": "MAP_SIX_ISLAND_OUTCAST_ISLAND",
+          "base_label": "sSixIslandOutcastIsland_LeafGreen",
           "water_mons": {
             "encounter_rate": 2,
             "mons": [
               {
                 "min_level": 5,
-                "max_level": 35,
+                "max_level": 20,
                 "species": "SPECIES_TENTACOOL"
               },
               {
-                "min_level": 5,
-                "max_level": 15,
-                "species": "SPECIES_HOPPIP"
+                "min_level": 20,
+                "max_level": 35,
+                "species": "SPECIES_TENTACOOL"
               },
               {
                 "min_level": 5,
@@ -6149,11 +6178,7 @@
                 "species": "SPECIES_HOPPIP"
               }
             ]
-          }
-        },
-        {
-          "map": "MAP_SIX_ISLAND_OUTCAST_ISLAND",
-          "base_label": "sSixIslandOutcastIsland_LeafGreen",
+          },
           "fishing_mons": {
             "encounter_rate": 20,
             "mons": [
@@ -6186,31 +6211,6 @@
                 "min_level": 15,
                 "max_level": 25,
                 "species": "SPECIES_HORSEA"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 20,
-                "species": "SPECIES_TENTACOOL"
-              },
-              {
-                "min_level": 20,
-                "max_level": 35,
-                "species": "SPECIES_TENTACOOL"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_HOPPIP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_HOPPIP"
               }
             ]
           }
@@ -6218,6 +6218,31 @@
         {
           "map": "MAP_SIX_ISLAND_GREEN_PATH",
           "base_label": "sSixIslandGreenPath_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 20,
+                "species": "SPECIES_TENTACOOL"
+              },
+              {
+                "min_level": 20,
+                "max_level": 35,
+                "species": "SPECIES_TENTACOOL"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_TENTACOOL"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_TENTACOOL"
+              }
+            ]
+          },
           "fishing_mons": {
             "encounter_rate": 20,
             "mons": [
@@ -6252,7 +6277,11 @@
                 "species": "SPECIES_HORSEA"
               }
             ]
-          },
+          }
+        },
+        {
+          "map": "MAP_SIX_ISLAND_WATER_PATH",
+          "base_label": "sSixIslandWaterPath_LeafGreen",
           "water_mons": {
             "encounter_rate": 2,
             "mons": [
@@ -6277,11 +6306,7 @@
                 "species": "SPECIES_TENTACOOL"
               }
             ]
-          }
-        },
-        {
-          "map": "MAP_SIX_ISLAND_WATER_PATH",
-          "base_label": "sSixIslandWaterPath_LeafGreen",
+          },
           "land_mons": {
             "encounter_rate": 21,
             "mons": [
@@ -6303,7 +6328,7 @@
               {
                 "min_level": 48,
                 "max_level": 48,
-                "species": "SPECIES_FEAROW"
+                "species": "SPECIES_FARFETCHD"
               },
               {
                 "min_level": 15,
@@ -6328,7 +6353,7 @@
               {
                 "min_level": 50,
                 "max_level": 50,
-                "species": "SPECIES_FEAROW"
+                "species": "SPECIES_FARFETCHD"
               },
               {
                 "min_level": 47,
@@ -6371,19 +6396,23 @@
                 "species": "SPECIES_HORSEA"
               }
             ]
-          },
+          }
+        },
+        {
+          "map": "MAP_SIX_ISLAND_RUIN_VALLEY",
+          "base_label": "sSixIslandRuinValley_LeafGreen",
           "water_mons": {
             "encounter_rate": 2,
             "mons": [
               {
                 "min_level": 5,
                 "max_level": 20,
-                "species": "SPECIES_TENTACOOL"
+                "species": "SPECIES_WOOPER"
               },
               {
-                "min_level": 20,
-                "max_level": 35,
-                "species": "SPECIES_TENTACOOL"
+                "min_level": 10,
+                "max_level": 20,
+                "species": "SPECIES_WOOPER"
               },
               {
                 "min_level": 5,
@@ -6396,11 +6425,7 @@
                 "species": "SPECIES_TENTACOOL"
               }
             ]
-          }
-        },
-        {
-          "map": "MAP_SIX_ISLAND_RUIN_VALLEY",
-          "base_label": "sSixIslandRuinValley_LeafGreen",
+          },
           "land_mons": {
             "encounter_rate": 21,
             "mons": [
@@ -6427,7 +6452,7 @@
               {
                 "min_level": 49,
                 "max_level": 49,
-                "species": "SPECIES_FEAROW"
+                "species": "SPECIES_GLIGAR"
               },
               {
                 "min_level": 43,
@@ -6437,7 +6462,7 @@
               {
                 "min_level": 25,
                 "max_level": 25,
-                "species": "SPECIES_WOBBUFFET"
+                "species": "SPECIES_WYNAUT"
               },
               {
                 "min_level": 41,
@@ -6490,19 +6515,23 @@
                 "species": "SPECIES_POLIWAG"
               }
             ]
-          },
+          }
+        },
+        {
+          "map": "MAP_SEVEN_ISLAND_TRAINER_TOWER",
+          "base_label": "sSevenIslandTrainerTower_LeafGreen",
           "water_mons": {
             "encounter_rate": 2,
             "mons": [
               {
                 "min_level": 5,
                 "max_level": 20,
-                "species": "SPECIES_WOOPER"
+                "species": "SPECIES_TENTACOOL"
               },
               {
-                "min_level": 10,
-                "max_level": 20,
-                "species": "SPECIES_WOOPER"
+                "min_level": 20,
+                "max_level": 35,
+                "species": "SPECIES_TENTACOOL"
               },
               {
                 "min_level": 5,
@@ -6515,11 +6544,7 @@
                 "species": "SPECIES_TENTACOOL"
               }
             ]
-          }
-        },
-        {
-          "map": "MAP_SEVEN_ISLAND_TRAINER_TOWER",
-          "base_label": "sSevenIslandTrainerTower_LeafGreen",
+          },
           "fishing_mons": {
             "encounter_rate": 20,
             "mons": [
@@ -6554,31 +6579,6 @@
                 "species": "SPECIES_HORSEA"
               }
             ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 20,
-                "species": "SPECIES_TENTACOOL"
-              },
-              {
-                "min_level": 20,
-                "max_level": 35,
-                "species": "SPECIES_TENTACOOL"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_TENTACOOL"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_TENTACOOL"
-              }
-            ]
           }
         },
         {
@@ -6605,7 +6605,7 @@
               {
                 "min_level": 48,
                 "max_level": 48,
-                "species": "SPECIES_FEAROW"
+                "species": "SPECIES_GLIGAR"
               },
               {
                 "min_level": 15,
@@ -6620,7 +6620,7 @@
               {
                 "min_level": 50,
                 "max_level": 50,
-                "species": "SPECIES_FEAROW"
+                "species": "SPECIES_GLIGAR"
               },
               {
                 "min_level": 41,
@@ -6664,7 +6664,7 @@
               {
                 "min_level": 50,
                 "max_level": 50,
-                "species": "SPECIES_FEAROW"
+                "species": "SPECIES_BALTOY"
               },
               {
                 "min_level": 52,
@@ -6684,7 +6684,7 @@
               {
                 "min_level": 30,
                 "max_level": 30,
-                "species": "SPECIES_SKARMORY"
+                "species": "SPECIES_BALTOY"
               },
               {
                 "min_level": 15,
@@ -6732,6 +6732,31 @@
         {
           "map": "MAP_SEVEN_ISLAND_TANOBY_RUINS",
           "base_label": "sSevenIslandTanobyRuins_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 20,
+                "species": "SPECIES_TENTACOOL"
+              },
+              {
+                "min_level": 20,
+                "max_level": 35,
+                "species": "SPECIES_TENTACOOL"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_TENTACOOL"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_TENTACOOL"
+              }
+            ]
+          },
           "fishing_mons": {
             "encounter_rate": 20,
             "mons": [
@@ -6764,31 +6789,6 @@
                 "min_level": 15,
                 "max_level": 25,
                 "species": "SPECIES_HORSEA"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 20,
-                "species": "SPECIES_TENTACOOL"
-              },
-              {
-                "min_level": 20,
-                "max_level": 35,
-                "species": "SPECIES_TENTACOOL"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_TENTACOOL"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_TENTACOOL"
               }
             ]
           }
@@ -6973,6 +6973,31 @@
         {
           "map": "MAP_ROUTE4",
           "base_label": "sRoute4_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 10,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 10,
+                "max_level": 20,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              }
+            ]
+          },
           "land_mons": {
             "encounter_rate": 21,
             "mons": [
@@ -7059,31 +7084,6 @@
               {
                 "min_level": 15,
                 "max_level": 25,
-                "species": "SPECIES_FEEBAS"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 10,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 10,
-                "max_level": 20,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
                 "species": "SPECIES_FEEBAS"
               }
             ]
@@ -7151,6 +7151,31 @@
         {
           "map": "MAP_ROUTE6",
           "base_label": "sRoute6_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 20,
+                "max_level": 25,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 20,
+                "max_level": 25,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              }
+            ]
+          },
           "land_mons": {
             "encounter_rate": 21,
             "mons": [
@@ -7238,31 +7263,6 @@
                 "min_level": 15,
                 "max_level": 25,
                 "species": "SPECIES_MAGIKARP"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 20,
-                "max_level": 25,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 20,
-                "max_level": 25,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
               }
             ]
           }
@@ -7447,6 +7447,31 @@
         {
           "map": "MAP_ROUTE10",
           "base_label": "sRoute10_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 10,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 10,
+                "max_level": 20,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              }
+            ]
+          },
           "land_mons": {
             "encounter_rate": 21,
             "mons": [
@@ -7534,31 +7559,6 @@
                 "min_level": 15,
                 "max_level": 25,
                 "species": "SPECIES_MAGIKARP"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 10,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 10,
-                "max_level": 20,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
               }
             ]
           }
@@ -7566,6 +7566,31 @@
         {
           "map": "MAP_ROUTE11",
           "base_label": "sRoute11_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 10,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 10,
+                "max_level": 20,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              }
+            ]
+          },
           "land_mons": {
             "encounter_rate": 21,
             "mons": [
@@ -7652,31 +7677,6 @@
               {
                 "min_level": 15,
                 "max_level": 25,
-                "species": "SPECIES_FEEBAS"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 10,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 10,
-                "max_level": 20,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
                 "species": "SPECIES_FEEBAS"
               }
             ]
@@ -7685,6 +7685,31 @@
         {
           "map": "MAP_ROUTE12",
           "base_label": "sRoute12_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 10,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 10,
+                "max_level": 20,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              }
+            ]
+          },
           "land_mons": {
             "encounter_rate": 21,
             "mons": [
@@ -7774,7 +7799,11 @@
                 "species": "SPECIES_MAGIKARP"
               }
             ]
-          },
+          }
+        },
+        {
+          "map": "MAP_ROUTE13",
+          "base_label": "sRoute13_LeafGreen",
           "water_mons": {
             "encounter_rate": 2,
             "mons": [
@@ -7786,12 +7815,12 @@
               {
                 "min_level": 10,
                 "max_level": 20,
-                "species": "SPECIES_MAGIKARP"
+                "species": "SPECIES_FEEBAS"
               },
               {
                 "min_level": 5,
                 "max_level": 5,
-                "species": "SPECIES_FEEBAS"
+                "species": "SPECIES_MAGIKARP"
               },
               {
                 "min_level": 5,
@@ -7799,11 +7828,7 @@
                 "species": "SPECIES_FEEBAS"
               }
             ]
-          }
-        },
-        {
-          "map": "MAP_ROUTE13",
-          "base_label": "sRoute13_LeafGreen",
+          },
           "land_mons": {
             "encounter_rate": 21,
             "mons": [
@@ -7891,31 +7916,6 @@
                 "min_level": 15,
                 "max_level": 25,
                 "species": "SPECIES_MAGIKARP"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 10,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 10,
-                "max_level": 20,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
               }
             ]
           }
@@ -8218,41 +8218,6 @@
         {
           "map": "MAP_ROUTE19",
           "base_label": "sRoute19_LeafGreen",
-          "fishing_mons": {
-            "encounter_rate": 20,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 15,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 15,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 15,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 15,
-                "max_level": 25,
-                "species": "SPECIES_MAGIKARP"
-              }
-            ]
-          },
           "water_mons": {
             "encounter_rate": 2,
             "mons": [
@@ -8277,11 +8242,7 @@
                 "species": "SPECIES_QWILFISH"
               }
             ]
-          }
-        },
-        {
-          "map": "MAP_ROUTE20",
-          "base_label": "sRoute20_LeafGreen",
+          },
           "fishing_mons": {
             "encounter_rate": 20,
             "mons": [
@@ -8316,7 +8277,11 @@
                 "species": "SPECIES_MAGIKARP"
               }
             ]
-          },
+          }
+        },
+        {
+          "map": "MAP_ROUTE20",
+          "base_label": "sRoute20_LeafGreen",
           "water_mons": {
             "encounter_rate": 2,
             "mons": [
@@ -8341,11 +8306,71 @@
                 "species": "SPECIES_BEAUTIFLY"
               }
             ]
+          },
+          "fishing_mons": {
+            "encounter_rate": 20,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 15,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 15,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 15,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 15,
+                "max_level": 25,
+                "species": "SPECIES_MAGIKARP"
+              }
+            ]
           }
         },
         {
           "map": "MAP_ROUTE21_NORTH",
           "base_label": "sRoute21North_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 10,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 10,
+                "max_level": 20,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              }
+            ]
+          },
           "land_mons": {
             "encounter_rate": 14,
             "mons": [
@@ -8432,31 +8457,6 @@
               {
                 "min_level": 15,
                 "max_level": 25,
-                "species": "SPECIES_FEEBAS"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 10,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 10,
-                "max_level": 20,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
                 "species": "SPECIES_FEEBAS"
               }
             ]
@@ -8465,6 +8465,31 @@
         {
           "map": "MAP_ROUTE21_SOUTH",
           "base_label": "sRoute21South_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 10,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 10,
+                "max_level": 20,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              }
+            ]
+          },
           "land_mons": {
             "encounter_rate": 14,
             "mons": [
@@ -8554,24 +8579,28 @@
                 "species": "SPECIES_FEEBAS"
               }
             ]
-          },
+          }
+        },
+        {
+          "map": "MAP_ROUTE22",
+          "base_label": "sRoute22_LeafGreen",
           "water_mons": {
             "encounter_rate": 2,
             "mons": [
               {
-                "min_level": 5,
-                "max_level": 10,
+                "min_level": 20,
+                "max_level": 25,
                 "species": "SPECIES_MAGIKARP"
               },
               {
-                "min_level": 10,
-                "max_level": 20,
-                "species": "SPECIES_MAGIKARP"
+                "min_level": 20,
+                "max_level": 25,
+                "species": "SPECIES_FEEBAS"
               },
               {
                 "min_level": 5,
                 "max_level": 5,
-                "species": "SPECIES_FEEBAS"
+                "species": "SPECIES_MAGIKARP"
               },
               {
                 "min_level": 5,
@@ -8579,11 +8608,7 @@
                 "species": "SPECIES_FEEBAS"
               }
             ]
-          }
-        },
-        {
-          "map": "MAP_ROUTE22",
-          "base_label": "sRoute22_LeafGreen",
+          },
           "land_mons": {
             "encounter_rate": 21,
             "mons": [
@@ -8670,31 +8695,6 @@
               {
                 "min_level": 15,
                 "max_level": 25,
-                "species": "SPECIES_FEEBAS"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 20,
-                "max_level": 25,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 20,
-                "max_level": 25,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
                 "species": "SPECIES_FEEBAS"
               }
             ]
@@ -8703,96 +8703,6 @@
         {
           "map": "MAP_ROUTE23",
           "base_label": "sRoute23_LeafGreen",
-          "land_mons": {
-            "encounter_rate": 21,
-            "mons": [
-              {
-                "min_level": 49,
-                "max_level": 50,
-                "species": "SPECIES_CLAYDOL"
-              },
-              {
-                "min_level": 49,
-                "max_level": 50,
-                "species": "SPECIES_CLAYDOL"
-              },
-              {
-                "min_level": 49,
-                "max_level": 50,
-                "species": "SPECIES_LUNATONE"
-              },
-              {
-                "min_level": 49,
-                "max_level": 50,
-                "species": "SPECIES_LUNATONE"
-              },
-              {
-                "min_level": 49,
-                "max_level": 50,
-                "species": "SPECIES_SOLROCK"
-              },
-              {
-                "min_level": 49,
-                "max_level": 50,
-                "species": "SPECIES_SOLROCK"
-              },
-              {
-                "min_level": 49,
-                "max_level": 50,
-                "species": "SPECIES_SOLROCK"
-              },
-              {
-                "min_level": 49,
-                "max_level": 50,
-                "species": "SPECIES_ROSELIA"
-              },
-              {
-                "min_level": 49,
-                "max_level": 50,
-                "species": "SPECIES_ROSELIA"
-              },
-              {
-                "min_level": 49,
-                "max_level": 50,
-                "species": "SPECIES_ROSELIA"
-              }
-            ]
-          },
-          "fishing_mons": {
-            "encounter_rate": 20,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 15,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 15,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 15,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 15,
-                "max_level": 25,
-                "species": "SPECIES_FEEBAS"
-              }
-            ]
-          },
           "water_mons": {
             "encounter_rate": 2,
             "mons": [
@@ -8817,63 +8727,59 @@
                 "species": "SPECIES_FEEBAS"
               }
             ]
-          }
-        },
-        {
-          "map": "MAP_ROUTE24",
-          "base_label": "sRoute24_LeafGreen",
+          },
           "land_mons": {
             "encounter_rate": 21,
             "mons": [
               {
-                "min_level": 12,
-                "max_level": 13,
-                "species": "SPECIES_LUVDISC"
+                "min_level": 49,
+                "max_level": 50,
+                "species": "SPECIES_CLAYDOL"
               },
               {
-                "min_level": 12,
-                "max_level": 13,
-                "species": "SPECIES_LUVDISC"
+                "min_level": 49,
+                "max_level": 50,
+                "species": "SPECIES_CLAYDOL"
               },
               {
-                "min_level": 12,
-                "max_level": 13,
-                "species": "SPECIES_SURSKIT"
+                "min_level": 49,
+                "max_level": 50,
+                "species": "SPECIES_LUNATONE"
               },
               {
-                "min_level": 12,
-                "max_level": 13,
-                "species": "SPECIES_SURSKIT"
+                "min_level": 49,
+                "max_level": 50,
+                "species": "SPECIES_LUNATONE"
               },
               {
-                "min_level": 12,
-                "max_level": 13,
-                "species": "SPECIES_SEEL"
+                "min_level": 49,
+                "max_level": 50,
+                "species": "SPECIES_SOLROCK"
               },
               {
-                "min_level": 12,
-                "max_level": 13,
-                "species": "SPECIES_SEEL"
+                "min_level": 49,
+                "max_level": 50,
+                "species": "SPECIES_SOLROCK"
               },
               {
-                "min_level": 12,
-                "max_level": 13,
-                "species": "SPECIES_SEEL"
+                "min_level": 49,
+                "max_level": 50,
+                "species": "SPECIES_SOLROCK"
               },
               {
-                "min_level": 12,
-                "max_level": 13,
-                "species": "SPECIES_MUDKIP"
+                "min_level": 49,
+                "max_level": 50,
+                "species": "SPECIES_ROSELIA"
               },
               {
-                "min_level": 12,
-                "max_level": 13,
-                "species": "SPECIES_MUDKIP"
+                "min_level": 49,
+                "max_level": 50,
+                "species": "SPECIES_ROSELIA"
               },
               {
-                "min_level": 12,
-                "max_level": 13,
-                "species": "SPECIES_MUDKIP"
+                "min_level": 49,
+                "max_level": 50,
+                "species": "SPECIES_ROSELIA"
               }
             ]
           },
@@ -8903,15 +8809,19 @@
               {
                 "min_level": 5,
                 "max_level": 15,
-                "species": "SPECIES_FEEBAS"
+                "species": "SPECIES_MAGIKARP"
               },
               {
                 "min_level": 15,
                 "max_level": 25,
-                "species": "SPECIES_MAGIKARP"
+                "species": "SPECIES_FEEBAS"
               }
             ]
-          },
+          }
+        },
+        {
+          "map": "MAP_ROUTE24",
+          "base_label": "sRoute24_LeafGreen",
           "water_mons": {
             "encounter_rate": 2,
             "mons": [
@@ -8936,11 +8846,126 @@
                 "species": "SPECIES_FEEBAS"
               }
             ]
+          },
+          "land_mons": {
+            "encounter_rate": 21,
+            "mons": [
+              {
+                "min_level": 12,
+                "max_level": 13,
+                "species": "SPECIES_LUVDISC"
+              },
+              {
+                "min_level": 12,
+                "max_level": 13,
+                "species": "SPECIES_LUVDISC"
+              },
+              {
+                "min_level": 12,
+                "max_level": 13,
+                "species": "SPECIES_SURSKIT"
+              },
+              {
+                "min_level": 12,
+                "max_level": 13,
+                "species": "SPECIES_SURSKIT"
+              },
+              {
+                "min_level": 12,
+                "max_level": 13,
+                "species": "SPECIES_SEEL"
+              },
+              {
+                "min_level": 12,
+                "max_level": 13,
+                "species": "SPECIES_SEEL"
+              },
+              {
+                "min_level": 12,
+                "max_level": 13,
+                "species": "SPECIES_SEEL"
+              },
+              {
+                "min_level": 12,
+                "max_level": 13,
+                "species": "SPECIES_MUDKIP"
+              },
+              {
+                "min_level": 12,
+                "max_level": 13,
+                "species": "SPECIES_MUDKIP"
+              },
+              {
+                "min_level": 12,
+                "max_level": 13,
+                "species": "SPECIES_MUDKIP"
+              }
+            ]
+          },
+          "fishing_mons": {
+            "encounter_rate": 20,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 15,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 15,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 15,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 15,
+                "max_level": 25,
+                "species": "SPECIES_MAGIKARP"
+              }
+            ]
           }
         },
         {
           "map": "MAP_ROUTE25",
           "base_label": "sRoute25_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 20,
+                "max_level": 25,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 20,
+                "max_level": 25,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              }
+            ]
+          },
           "land_mons": {
             "encounter_rate": 21,
             "mons": [
@@ -9030,24 +9055,28 @@
                 "species": "SPECIES_MAGIKARP"
               }
             ]
-          },
+          }
+        },
+        {
+          "map": "MAP_PALLET_TOWN",
+          "base_label": "sPalletTown_LeafGreen",
           "water_mons": {
-            "encounter_rate": 2,
+            "encounter_rate": 1,
             "mons": [
               {
-                "min_level": 20,
-                "max_level": 25,
+                "min_level": 5,
+                "max_level": 10,
                 "species": "SPECIES_MAGIKARP"
               },
               {
-                "min_level": 20,
-                "max_level": 25,
-                "species": "SPECIES_FEEBAS"
+                "min_level": 10,
+                "max_level": 20,
+                "species": "SPECIES_MAGIKARP"
               },
               {
                 "min_level": 5,
                 "max_level": 5,
-                "species": "SPECIES_MAGIKARP"
+                "species": "SPECIES_FEEBAS"
               },
               {
                 "min_level": 5,
@@ -9055,11 +9084,7 @@
                 "species": "SPECIES_FEEBAS"
               }
             ]
-          }
-        },
-        {
-          "map": "MAP_PALLET_TOWN",
-          "base_label": "sPalletTown_LeafGreen",
+          },
           "fishing_mons": {
             "encounter_rate": 10,
             "mons": [
@@ -9094,49 +9119,14 @@
                 "species": "SPECIES_MAGIKARP"
               }
             ]
-          },
-          "water_mons": {
-            "encounter_rate": 1,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 10,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 10,
-                "max_level": 20,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
-              }
-            ]
           }
         },
         {
           "map": "MAP_VIRIDIAN_CITY",
           "base_label": "sViridianCity_LeafGreen3",
-          "fishing_mons": {
+          "water_mons": {
             "encounter_rate": 0,
             "mons": [
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
-              },
               {
                 "min_level": 5,
                 "max_level": 5,
@@ -9189,9 +9179,19 @@
               }
             ]
           },
-          "water_mons": {
+          "fishing_mons": {
             "encounter_rate": 0,
             "mons": [
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              },
               {
                 "min_level": 5,
                 "max_level": 5,
@@ -9218,6 +9218,31 @@
         {
           "map": "MAP_CERULEAN_CITY",
           "base_label": "sCeruleanCity_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 1,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 10,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 10,
+                "max_level": 20,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              }
+            ]
+          },
           "fishing_mons": {
             "encounter_rate": 10,
             "mons": [
@@ -9250,31 +9275,6 @@
                 "min_level": 15,
                 "max_level": 25,
                 "species": "SPECIES_MAGIKARP"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 1,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 10,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 10,
-                "max_level": 20,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
               }
             ]
           }
@@ -9282,6 +9282,31 @@
         {
           "map": "MAP_VERMILION_CITY",
           "base_label": "sVermilionCity_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 1,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 10,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 10,
+                "max_level": 20,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              }
+            ]
+          },
           "fishing_mons": {
             "encounter_rate": 10,
             "mons": [
@@ -9314,31 +9339,6 @@
                 "min_level": 15,
                 "max_level": 25,
                 "species": "SPECIES_MAGIKARP"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 1,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 10,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 10,
-                "max_level": 20,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
               }
             ]
           }
@@ -9346,41 +9346,6 @@
         {
           "map": "MAP_CELADON_CITY",
           "base_label": "sCeladonCity_LeafGreen",
-          "fishing_mons": {
-            "encounter_rate": 10,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 15,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 15,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 15,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 15,
-                "max_level": 25,
-                "species": "SPECIES_FEEBAS"
-              }
-            ]
-          },
           "water_mons": {
             "encounter_rate": 1,
             "mons": [
@@ -9405,11 +9370,71 @@
                 "species": "SPECIES_MAGIKARP"
               }
             ]
+          },
+          "fishing_mons": {
+            "encounter_rate": 10,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 15,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 15,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 15,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 15,
+                "max_level": 25,
+                "species": "SPECIES_FEEBAS"
+              }
+            ]
           }
         },
         {
           "map": "MAP_FUCHSIA_CITY",
           "base_label": "sFuchsiaCity_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 1,
+            "mons": [
+              {
+                "min_level": 20,
+                "max_level": 25,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 20,
+                "max_level": 25,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_MAGIKARP"
+              }
+            ]
+          },
           "fishing_mons": {
             "encounter_rate": 10,
             "mons": [
@@ -9441,31 +9466,6 @@
               {
                 "min_level": 15,
                 "max_level": 25,
-                "species": "SPECIES_MAGIKARP"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 1,
-            "mons": [
-              {
-                "min_level": 20,
-                "max_level": 25,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 20,
-                "max_level": 25,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
                 "species": "SPECIES_MAGIKARP"
               }
             ]
@@ -9474,41 +9474,6 @@
         {
           "map": "MAP_CINNABAR_ISLAND",
           "base_label": "sCinnabarIsland_LeafGreen",
-          "fishing_mons": {
-            "encounter_rate": 10,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 15,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 5,
-                "max_level": 15,
-                "species": "SPECIES_MAGIKARP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 15,
-                "species": "SPECIES_FEEBAS"
-              },
-              {
-                "min_level": 15,
-                "max_level": 25,
-                "species": "SPECIES_MAGIKARP"
-              }
-            ]
-          },
           "water_mons": {
             "encounter_rate": 1,
             "mons": [
@@ -9533,11 +9498,7 @@
                 "species": "SPECIES_FEEBAS"
               }
             ]
-          }
-        },
-        {
-          "map": "MAP_ONE_ISLAND",
-          "base_label": "sOneIsland_LeafGreen",
+          },
           "fishing_mons": {
             "encounter_rate": 10,
             "mons": [
@@ -9572,7 +9533,11 @@
                 "species": "SPECIES_MAGIKARP"
               }
             ]
-          },
+          }
+        },
+        {
+          "map": "MAP_ONE_ISLAND",
+          "base_label": "sOneIsland_LeafGreen",
           "water_mons": {
             "encounter_rate": 1,
             "mons": [
@@ -9597,11 +9562,71 @@
                 "species": "SPECIES_FEEBAS"
               }
             ]
+          },
+          "fishing_mons": {
+            "encounter_rate": 10,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 15,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 5,
+                "max_level": 15,
+                "species": "SPECIES_MAGIKARP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 15,
+                "species": "SPECIES_FEEBAS"
+              },
+              {
+                "min_level": 15,
+                "max_level": 25,
+                "species": "SPECIES_MAGIKARP"
+              }
+            ]
           }
         },
         {
           "map": "MAP_FOUR_ISLAND",
           "base_label": "sFourIsland_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 2,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 15,
+                "species": "SPECIES_WOOPER"
+              },
+              {
+                "min_level": 5,
+                "max_level": 35,
+                "species": "SPECIES_PSYDUCK"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_PSYDUCK"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_PSYDUCK"
+              }
+            ]
+          },
           "fishing_mons": {
             "encounter_rate": 20,
             "mons": [
@@ -9636,36 +9661,36 @@
                 "species": "SPECIES_POLIWAG"
               }
             ]
-          },
-          "water_mons": {
-            "encounter_rate": 2,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 15,
-                "species": "SPECIES_WOOPER"
-              },
-              {
-                "min_level": 5,
-                "max_level": 35,
-                "species": "SPECIES_PSYDUCK"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_PSYDUCK"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_PSYDUCK"
-              }
-            ]
           }
         },
         {
           "map": "MAP_FIVE_ISLAND",
           "base_label": "sFiveIsland_LeafGreen",
+          "water_mons": {
+            "encounter_rate": 1,
+            "mons": [
+              {
+                "min_level": 5,
+                "max_level": 35,
+                "species": "SPECIES_TENTACOOL"
+              },
+              {
+                "min_level": 5,
+                "max_level": 15,
+                "species": "SPECIES_HOPPIP"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_TENTACOOL"
+              },
+              {
+                "min_level": 5,
+                "max_level": 5,
+                "species": "SPECIES_TENTACOOL"
+              }
+            ]
+          },
           "fishing_mons": {
             "encounter_rate": 10,
             "mons": [
@@ -9698,31 +9723,6 @@
                 "min_level": 15,
                 "max_level": 25,
                 "species": "SPECIES_HORSEA"
-              }
-            ]
-          },
-          "water_mons": {
-            "encounter_rate": 1,
-            "mons": [
-              {
-                "min_level": 5,
-                "max_level": 35,
-                "species": "SPECIES_TENTACOOL"
-              },
-              {
-                "min_level": 5,
-                "max_level": 15,
-                "species": "SPECIES_HOPPIP"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_TENTACOOL"
-              },
-              {
-                "min_level": 5,
-                "max_level": 5,
-                "species": "SPECIES_TENTACOOL"
               }
             ]
           }


### PR DESCRIPTION
Silph Co 1F One Way Warp Warning.  Triggers pre-silph rocket hide flag to warn you of the one way warp.  Different text afterwards.  Also removed all mons not in the game from Postgame locations though didn't try to make a good distribution of mons.  Mewtwo is now a ditto.